### PR TITLE
Reflect deprecation of entrust certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ The config file should be set up as follows:
     "ConsumerSecret": "BBBBBBBBBBBBBBBBBBBB",
     "AuthorizeCallbackUrl": 'https://www.mywebsite.com/xerocallback',
     "PrivateKeyPath" : "/some/path/to/partner_privatekey.pem",
-    "SSLCertPath" : "/some/path/to/partner_publickey.cer",
     "RunscopeBucketId" : "xxxyyyzzzz"
 }
 ```
@@ -90,7 +89,6 @@ The config file should be set up as follows:
 | ConsumerSecret       | The secret key from the developer portal that is required to authenticate your API calls | True      |
 | AuthorizeCallbackUrl | The callback that Xero should invoke when the authorization is successful.               | False     |
 | PrivateKeyPath       | The filesystem path to your privatekey.pem file to sign the API calls                    | False     |
-| SSLCertPath          | The filesystem path to your publickey.pem file to sign the API calls                     | False     |
 | RunscopeBucketId     | Your personal runscope bucket for debugging API calls                                    | False     |
 ---
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -455,7 +455,6 @@ populateOptions = function(configFilePath) {
         options["consumerSecret"] = config.ConsumerSecret;
         options["privateKeyPath"] = config.PrivateKeyPath;
         options["authorizeCallbackUrl"] = config.AuthorizeCallbackUrl;
-        options["sslCertPath"] = config.SSLCertPath;
         options["userAgent"] = config.UserAgent || "Xero - Node.js SDK";
         options["runscopeBucketId"] = config.RunscopeBucketId;
     } catch (e) {
@@ -582,7 +581,6 @@ var PartnerApplication = RequireAuthorizationApplication.extend({
         );
         //use SSL certificate
         var keyCert = fs.readFileSync(this.options.privateKeyPath);
-        var cert = fs.readFileSync(this.options.sslCertPath);
         this.oa._createClient = function(port, hostname, method, path, headers, sslEnabled) {
             var options = {
                 host: hostname,
@@ -590,8 +588,7 @@ var PartnerApplication = RequireAuthorizationApplication.extend({
                 path: path,
                 method: method,
                 headers: headers,
-                key: keyCert,
-                cert: cert
+                key: keyCert
             };
             var httpModel;
             if (sslEnabled) {

--- a/sample_app/sample_app.js
+++ b/sample_app/sample_app.js
@@ -4,7 +4,7 @@ var express = require('express'),
     LRU = require('lru-cache'),
     fs = require('fs'),
     nodemailer = require('nodemailer'),
-    publicConfigFile = "/Users/jordan.walsh/.xero/public_app_config.json";
+    publicConfigFile = "../public_app_config.json";
 
 function getXeroApp(session) {
     var config = {

--- a/test/accountingtests.js
+++ b/test/accountingtests.js
@@ -14,9 +14,9 @@ var currentApp;
 var organisationCountry = "";
 
 var APPTYPE = "PRIVATE";
-var privateConfigFile = "/Users/jordan.walsh/.xero/private_app_config.json";
-var publicConfigFile = "/Users/jordan.walsh/.xero/public_app_config.json";
-var partnerConfigFile = "/Users/jordan.walsh/.xero/partner_app_config.json";
+var privateConfigFile = "../private_app_config.json";
+var publicConfigFile = "../public_app_config.json";
+var partnerConfigFile = "../partner_app_config.json";
 var configFile = "";
 
 describe('create application', function() {

--- a/test/accountingtests.js
+++ b/test/accountingtests.js
@@ -152,7 +152,6 @@ describe('get access for public or partner application', function() {
                 it('should see application auth page', function(done) {
                     //console.log(browser.document.documentElement.innerHTML);
                     browser.assert.text('title', 'Xero | Authorise Application');
-                    browser.select('select', 'MWE5NzdkMDItZTAyNC00NGJkLTlmMGQtNjFiOGI4OWY2YTI4-ecmd9rxRfsM=');
 
                     if (APPTYPE === "PUBLIC") {
                         browser.pressButton("Allow access for 30 mins");

--- a/test/accountingtests.js
+++ b/test/accountingtests.js
@@ -13,38 +13,34 @@ process.on('uncaughtException', function(err) {
 var currentApp;
 var organisationCountry = "";
 
-var APPTYPE = "PRIVATE";
+var APPTYPE = "PARTNER";
 var privateConfigFile = "../private_app_config.json";
 var publicConfigFile = "../public_app_config.json";
 var partnerConfigFile = "../partner_app_config.json";
 var configFile = "";
 
-describe('create application', function() {
-    describe('create instance', function() {
-        it('init instance and set options', function(done) {
-            //This constructor looks in ~/.xero/config.json for settings
+before('init instance and set options', function(done) {
+    //This constructor looks in ~/.xero/config.json for settings
 
-            switch (APPTYPE) {
-                case "PRIVATE":
-                    configFile = privateConfigFile;
-                    currentApp = new xero.PrivateApplication(configFile);
-                    break;
-                case "PUBLIC":
-                    configFile = publicConfigFile;
-                    currentApp = new xero.PublicApplication(publicConfigFile, { runscopeBucketId: "ei635hnc0fem" });
-                    break;
-                case "PARTNER":
-                    configFile = partnerConfigFile;
-                    currentApp = new xero.PartnerApplication(partnerConfigFile, { authorizedCallbackUrl: "" });
-                    break;
-                default:
-                    throw "No App Type Set!!"
-            }
+    switch (APPTYPE) {
+        case "PRIVATE":
+            configFile = privateConfigFile;
+            currentApp = new xero.PrivateApplication(configFile);
+            break;
+        case "PUBLIC":
+            configFile = publicConfigFile;
+            currentApp = new xero.PublicApplication(publicConfigFile, { runscopeBucketId: "ei635hnc0fem" });
+            break;
+        case "PARTNER":
+            configFile = partnerConfigFile;
+            currentApp = new xero.PartnerApplication(partnerConfigFile, { authorizedCallbackUrl: "" });
+            break;
+        default:
+            throw "No App Type Set!!"
+    }
 
-            done();
-        })
-    });
-});
+    done();
+})
 
 describe('get access for public or partner application', function() {
     beforeEach(function() {

--- a/test/accountingtests.js
+++ b/test/accountingtests.js
@@ -43,6 +43,7 @@ before('init instance and set options', function(done) {
 })
 
 describe('get access for public or partner application', function() {
+    this.timeout(30000);
     beforeEach(function() {
         if (APPTYPE === "PRIVATE") {
             this.skip();


### PR DESCRIPTION
https://developer.xero.com/documentation/auth-and-limits/entrust-certificate-deprecation

I haven't actually been able to test this yet as the code relies on a private key file being present on the filesystem. It would be good to get some documentation on what the contents of this file need to be in order to run the suite.

Better yet might be to pass the key in as a string rather than relying on it being on disk. That way the test suite could pass in whatever testing values it needs.

For production usage, we could either include an `fs.readFileSync` call in the example usage or to maintain backwards compatibility, look for the file if (!passed_in_key).