### PR TITLE
Less lodash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@
 .nyc_output/
 .DS_Store
 .vscode
-*config.json
+testing_config.json

--- a/example_testing_config.json
+++ b/example_testing_config.json
@@ -1,0 +1,23 @@
+{
+    "APPTYPE": "PARTNER",
+    "partner": {
+        "AuthorizeCallbackUrl": null,
+        "ConsumerKey": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "PrivateKeyPath": "/some/path/to/privatekey.pem",
+        "UserAgent": "Tester (PARTNER) - Application for testing Xero",
+        "XeroPassword": "XXXXXXXXXX",
+        "XeroUsername": "foo@example.com"
+    },
+    "private": {
+        "ConsumerKey": "AAAAAAAAAAAAAAAAAA",
+        "ConsumerSecret": "BBBBBBBBBBBBBBBBBBBB",
+        "PrivateKeyPath": "/some/path/to/privatekey.pem",
+        "UserAgent": "Tester (PRIVATE) - Application for testing Xero"
+    },
+    "public": {
+        "AuthorizeCallbackUrl": "https://example.com/xerocallback",
+        "ConsumerKey": "AAAAAAAAAAAAAAAAAA",
+        "ConsumerSecret": "BBBBBBBBBBBBBBBBBBBB",
+        "UserAgent": "Tester (PUBLIC) - Application for testing Xero"
+    }
+}

--- a/example_testing_config.json
+++ b/example_testing_config.json
@@ -1,23 +1,23 @@
 {
     "APPTYPE": "PARTNER",
     "partner": {
-        "AuthorizeCallbackUrl": null,
-        "ConsumerKey": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-        "PrivateKeyPath": "/some/path/to/privatekey.pem",
-        "UserAgent": "Tester (PARTNER) - Application for testing Xero",
-        "XeroPassword": "XXXXXXXXXX",
-        "XeroUsername": "foo@example.com"
+        "authorizeCallbackUrl": null,
+        "consumerKey": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "privateKeyPath": "/some/path/to/privatekey.pem",
+        "userAgent": "Tester (PARTNER) - Application for testing Xero",
+        "xeroPassword": "XXXXXXXXXX",
+        "xeroUsername": "foo@example.com"
     },
     "private": {
-        "ConsumerKey": "AAAAAAAAAAAAAAAAAA",
-        "ConsumerSecret": "BBBBBBBBBBBBBBBBBBBB",
-        "PrivateKeyPath": "/some/path/to/privatekey.pem",
-        "UserAgent": "Tester (PRIVATE) - Application for testing Xero"
+        "consumerKey": "AAAAAAAAAAAAAAAAAA",
+        "consumerSecret": "BBBBBBBBBBBBBBBBBBBB",
+        "privateKeyPath": "/some/path/to/privatekey.pem",
+        "userAgent": "Tester (PRIVATE) - Application for testing Xero"
     },
     "public": {
-        "AuthorizeCallbackUrl": "https://example.com/xerocallback",
-        "ConsumerKey": "AAAAAAAAAAAAAAAAAA",
-        "ConsumerSecret": "BBBBBBBBBBBBBBBBBBBB",
-        "UserAgent": "Tester (PUBLIC) - Application for testing Xero"
+        "authorizeCallbackUrl": "https://example.com/xerocallback",
+        "consumerKey": "AAAAAAAAAAAAAAAAAA",
+        "consumerSecret": "BBBBBBBBBBBBBBBBBBBB",
+        "userAgent": "Tester (PUBLIC) - Application for testing Xero"
     }
 }

--- a/lib/application.js
+++ b/lib/application.js
@@ -16,7 +16,7 @@ function Batch(application) {
     this._operations = [];
 }
 
-_.extend(Batch.prototype, {
+Object.assign(Batch.prototype, {
     get: function() {
 
     },
@@ -61,7 +61,7 @@ function Application(options) {
 
 Application.extend = extend;
 
-_.extend(Application, {
+Object.assign(Application, {
     defaults: {
         baseUrl: 'https://api.xero.com',
         consumerSecret: '',
@@ -76,7 +76,7 @@ _.extend(Application, {
     }
 })
 
-_.extend(Application.prototype, {
+Object.assign(Application.prototype, {
     init: function() {
         if (this.options["runscopeBucketId"] && this.options["runscopeBucketId"] !== "") {
             this.options.baseUrl = "https://api-xero-com-" + this.options["runscopeBucketId"] + ".runscope.net";
@@ -423,7 +423,7 @@ _.extend(Application.prototype, {
 var PrivateApplication = Application.extend({
     constructor: function(config) {
         logger.debug('PrivateApplication::constructor');
-        Application.call(this, _.extend({}, config, { type: 'private' }));
+        Application.call(this, Object.assign({}, config, { type: 'private' }));
     },
     init: function() {
         Application.prototype.init.apply(this, arguments);
@@ -485,7 +485,7 @@ var RequireAuthorizationApplication = Application.extend({
         });
     },
     buildAuthorizeUrl: function(requestToken, other) {
-        var q = _.extend({}, { oauth_token: requestToken }, other);
+        var q = Object.assign({}, { oauth_token: requestToken }, other);
         return this.options.baseUrl + this.options.authorizeUrl + '?' + querystring.stringify(q);
     },
     setOptions: function(options) {
@@ -498,7 +498,7 @@ var RequireAuthorizationApplication = Application.extend({
 var PublicApplication = RequireAuthorizationApplication.extend({
     constructor: function(config) {
         logger.debug('PublicApplication::constructor');
-        RequireAuthorizationApplication.call(this, _.extend({}, config, { type: 'public' }));
+        RequireAuthorizationApplication.call(this, Object.assign({}, config, { type: 'public' }));
     },
     init: function() {
         RequireAuthorizationApplication.prototype.init.apply(this, arguments);
@@ -518,7 +518,7 @@ var PublicApplication = RequireAuthorizationApplication.extend({
 var PartnerApplication = RequireAuthorizationApplication.extend({
     constructor: function(config) {
         logger.debug('PartnerApplication::constructor');
-        RequireAuthorizationApplication.call(this, _.extend({}, config, { type: 'partner' }));
+        RequireAuthorizationApplication.call(this, Object.assign({}, config, { type: 'partner' }));
     },
 
     init: function() {

--- a/lib/application.js
+++ b/lib/application.js
@@ -420,23 +420,9 @@ _.extend(Application.prototype, {
     }
 })
 
-populateOptions = function(config) {
-    var options = {};
-
-    options["consumerKey"] = config.ConsumerKey;
-    options["consumerSecret"] = config.ConsumerSecret;
-    options["privateKey"] = config.PrivateKey;
-    options["authorizeCallbackUrl"] = config.AuthorizeCallbackUrl;
-    options["userAgent"] = config.UserAgent || "Xero - Node.js SDK";
-    options["runscopeBucketId"] = config.RunscopeBucketId;
-
-    return options;
-}
-
 var PrivateApplication = Application.extend({
     constructor: function(config) {
         logger.debug('PrivateApplication::constructor');
-        config = populateOptions(config);
         Application.call(this, _.extend({}, config, { type: 'private' }));
     },
     init: function() {
@@ -512,7 +498,6 @@ var RequireAuthorizationApplication = Application.extend({
 var PublicApplication = RequireAuthorizationApplication.extend({
     constructor: function(config) {
         logger.debug('PublicApplication::constructor');
-        config = populateOptions(config);
         RequireAuthorizationApplication.call(this, _.extend({}, config, { type: 'public' }));
     },
     init: function() {
@@ -533,7 +518,6 @@ var PublicApplication = RequireAuthorizationApplication.extend({
 var PartnerApplication = RequireAuthorizationApplication.extend({
     constructor: function(config) {
         logger.debug('PartnerApplication::constructor');
-        config = populateOptions(config);
         RequireAuthorizationApplication.call(this, _.extend({}, config, { type: 'partner' }));
     },
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -2,7 +2,6 @@ var _ = require('lodash'),
     logger = require('./logger'),
     OAuth = require('./oauth/oauth').OAuth,
     OAuthEcho = require('./oauth/oauth').OAuthEcho,
-    fs = require('fs'),
     extend = require('./misc/extend'),
     dateformat = require('dateformat'),
     querystring = require('querystring'),
@@ -421,50 +420,28 @@ _.extend(Application.prototype, {
     }
 })
 
-populateOptions = function(configFilePath) {
-    if (!configFilePath) {
-        //look for the config file in the user's home directory
-        var homedir, config;
-
-        homedir = process.env.HOME || process.env.USERPROFILE;
-        if (homedir) {
-            configFilePath = homedir + '/.xero/config.json';
-        } else {
-            var err = 'Couldn\'t find config.json in your home dir [' + homedir + '/.xero]. Exiting...';
-            console.error(err);
-            throw err;
-        }
-    }
-
+populateOptions = function(config) {
     var options = {};
 
-    try {
-        logger.debug('configFilePath: ' + configFilePath);
-
-        config = require(configFilePath);
-        options["consumerKey"] = config.ConsumerKey;
-        options["consumerSecret"] = config.ConsumerSecret;
-        options["privateKeyPath"] = config.PrivateKeyPath;
-        options["authorizeCallbackUrl"] = config.AuthorizeCallbackUrl;
-        options["userAgent"] = config.UserAgent || "Xero - Node.js SDK";
-        options["runscopeBucketId"] = config.RunscopeBucketId;
-    } catch (e) {
-        var err = 'Couldn\'t read config.json from [' + configFilePath + ']. Exiting...';
-        console.error(err);
-    }
+    options["consumerKey"] = config.ConsumerKey;
+    options["consumerSecret"] = config.ConsumerSecret;
+    options["privateKey"] = config.PrivateKey;
+    options["authorizeCallbackUrl"] = config.AuthorizeCallbackUrl;
+    options["userAgent"] = config.UserAgent || "Xero - Node.js SDK";
+    options["runscopeBucketId"] = config.RunscopeBucketId;
 
     return options;
 }
 
 var PrivateApplication = Application.extend({
-    constructor: function(configFilePath, options) {
+    constructor: function(config) {
         logger.debug('PrivateApplication::constructor');
-        var options = _.merge(populateOptions(configFilePath), options);
-        Application.call(this, _.extend({}, options, { type: 'private' }));
+        config = populateOptions(config);
+        Application.call(this, _.extend({}, config, { type: 'private' }));
     },
     init: function() {
         Application.prototype.init.apply(this, arguments);
-        var rsaPrivateKey = fs.readFileSync(this.options.privateKeyPath, "utf8");
+        var rsaPrivateKey = this.options.privateKey;
         this.oa = new OAuth(
             null,
             null,
@@ -533,10 +510,10 @@ var RequireAuthorizationApplication = Application.extend({
 
 
 var PublicApplication = RequireAuthorizationApplication.extend({
-    constructor: function(configFilePath, args) {
+    constructor: function(config) {
         logger.debug('PublicApplication::constructor');
-        var params = _.merge(populateOptions(configFilePath), args);
-        RequireAuthorizationApplication.call(this, _.extend({}, params, { type: 'public' }));
+        config = populateOptions(config);
+        RequireAuthorizationApplication.call(this, _.extend({}, config, { type: 'public' }));
     },
     init: function() {
         RequireAuthorizationApplication.prototype.init.apply(this, arguments);
@@ -554,15 +531,15 @@ var PublicApplication = RequireAuthorizationApplication.extend({
 });
 
 var PartnerApplication = RequireAuthorizationApplication.extend({
-    constructor: function(configFilePath, options) {
+    constructor: function(config) {
         logger.debug('PartnerApplication::constructor');
-        var options = _.merge(populateOptions(configFilePath), options);
-        RequireAuthorizationApplication.call(this, _.extend({}, options, { type: 'partner' }));
+        config = populateOptions(config);
+        RequireAuthorizationApplication.call(this, _.extend({}, config, { type: 'partner' }));
     },
 
     init: function() {
         RequireAuthorizationApplication.prototype.init.apply(this, arguments);
-        var rsaPrivateKey = fs.readFileSync(this.options.privateKeyPath, "utf8");
+        var rsaPrivateKey = this.options.privateKey;
         this.oa = new OAuth(
             this.options.baseUrl + this.options.requestTokenUrl,
             this.options.baseUrl + this.options.accessTokenUrl,
@@ -574,7 +551,7 @@ var PartnerApplication = RequireAuthorizationApplication.extend({
             null, { 'User-Agent': this.options.userAgent }
         );
         //use SSL certificate
-        var keyCert = fs.readFileSync(this.options.privateKeyPath);
+        var keyCert = this.options.privateKey;
         this.oa._createClient = function(port, hostname, method, path, headers, sslEnabled) {
             var options = {
                 host: hostname,

--- a/lib/core.js
+++ b/lib/core.js
@@ -31,12 +31,12 @@ function Core(application, options) {
 }
 
 // Static
-_.extend(Core, {
+Object.assign(Core, {
 
 })
 
 // Instance
-_.extend(Core.prototype, {
+Object.assign(Core.prototype, {
 
 
 })

--- a/lib/entities/banktransaction.js
+++ b/lib/entities/banktransaction.js
@@ -48,7 +48,7 @@ var BankTransaction = Entity.extend(BankTransactionSchema, {
     },
     fromXmlObj: function(obj) {
         var self = this;
-        _.extend(self, _.omit(obj, 'LineItems', 'Contact'));
+        Object.assign(self, _.omit(obj, 'LineItems', 'Contact'));
         if (obj.LineItems) {
             var lineItems = this.application.asArray(obj.LineItems.LineItem);
             _.each(lineItems, function(lineItem) {
@@ -56,7 +56,7 @@ var BankTransaction = Entity.extend(BankTransactionSchema, {
             })
         }
         if (obj.Contact)
-            _.extend(self.Contact, new Contact(self.application).fromXmlObj(obj.Contact))
+            Object.assign(self.Contact, new Contact(self.application).fromXmlObj(obj.Contact))
 
         return this;
     },

--- a/lib/entities/banktransfer.js
+++ b/lib/entities/banktransfer.js
@@ -45,7 +45,7 @@ var BankTransfer = Entity.extend(BankTransferSchema, {
         return this._super(options);
     },
     fromXmlObj: function(obj) {
-        _.extend(this, obj);
+        Object.assign(this, obj);
         return this;
     },
     toXml: function() {

--- a/lib/entities/contact.js
+++ b/lib/entities/contact.js
@@ -79,7 +79,7 @@ var Contact = Entity.extend(ContactSchema, {
     },
     fromXmlObj: function(obj) {
         var self = this;
-        _.extend(self, _.omit(obj, 'Contact', 'LineItems', 'CreditNotes'));
+        Object.assign(self, _.omit(obj, 'Contact', 'LineItems', 'CreditNotes'));
         if (obj.Addresses) {
             this.extractArray(obj.Addresses.Address, this.Addresses);
         }

--- a/lib/entities/entity.js
+++ b/lib/entities/entity.js
@@ -34,7 +34,7 @@ module.exports.extend = function(schema, classProps, staticProps) {
             return _.clone(this.tracking._changes);
         },
         fromXmlObj: function(obj) {
-            return _.extend(this, obj);
+            return Object.assign(this, obj);
         },
         extractArray: function(src, dest) {
             var items = this.application.asArray(src);
@@ -45,7 +45,7 @@ module.exports.extend = function(schema, classProps, staticProps) {
         }
     })
 
-    return Entity.extend(_.extend(classProps, { Entity: Entity }), staticProps);
+    return Entity.extend(Object.assign(classProps, { Entity: Entity }), staticProps);
 
 }
 

--- a/lib/entities/invoice.js
+++ b/lib/entities/invoice.js
@@ -76,7 +76,7 @@ var Invoice = Entity.extend(InvoiceSchema, {
     },
     fromXmlObj: function(obj) {
         var self = this;
-        _.extend(self, _.omit(obj, 'LineItems', 'Payments'));
+        Object.assign(self, _.omit(obj, 'LineItems', 'Payments'));
         if (obj.LineItems) {
             this.extractArray(obj.LineItems.LineItem, this.LineItems);
         }
@@ -89,7 +89,7 @@ var Invoice = Entity.extend(InvoiceSchema, {
     },
     toXml: function() {
         var invoice = _.omit(this.toObject(), 'LineItems', 'Payments', 'CreditNotes', 'InvoiceID', 'HasAttachments', 'AmountDue', 'AmountPaid', 'FullyPaidOnDate', 'AmountCredited', 'UpdatedDateUTC');
-        _.extend(invoice, { LineItems: { LineItem: [] } });
+        Object.assign(invoice, { LineItems: { LineItem: [] } });
         _.forEach(this.LineItems, function(lineItem) {
             invoice.LineItems.LineItem.push(lineItem.toObject());
         });

--- a/lib/entities/journal.js
+++ b/lib/entities/journal.js
@@ -48,7 +48,7 @@ var Journal = Entity.extend(JournalSchema, {
     },
     fromXmlObj: function(obj) {
         var self = this;
-        _.extend(self, _.omit(obj, 'JournalLines'));
+        Object.assign(self, _.omit(obj, 'JournalLines'));
         if (obj.JournalLines) {
             var journalLines = this.application.asArray(obj.JournalLines.JournalLine);
             _.each(journalLines, function(journalLine) {

--- a/lib/entities/organisation.js
+++ b/lib/entities/organisation.js
@@ -56,7 +56,7 @@ var Organisation = Entity.extend(OrganisationSchema, {
     },
     fromXmlObj: function(obj) {
         var self = this;
-        _.extend(self, _.omit(obj, 'Addresses', 'Phones', 'ExternalLinks'));
+        Object.assign(self, _.omit(obj, 'Addresses', 'Phones', 'ExternalLinks'));
         if (obj.Addresses) {
             _.each(obj.Addresses.Address, function(address) {
                 self.Addresses.push(address);

--- a/lib/entities/payitems.js
+++ b/lib/entities/payitems.js
@@ -76,7 +76,7 @@ var PayItems = Entity.extend(PayItemsSchema, {
     },
     fromXmlObj: function(obj) {
         var self = this;
-        _.extend(self, _.omit(obj, 'BenefitTypes', 'EarningsTypes', 'ReimbursementTypes', 'DeductionTypes', 'TimeOffTypes'));
+        Object.assign(self, _.omit(obj, 'BenefitTypes', 'EarningsTypes', 'ReimbursementTypes', 'DeductionTypes', 'TimeOffTypes'));
         if (obj.BenefitTypes) {
             this.extractArray(obj.BenefitTypes.BenefitType, this.BenefitTypes);
         }

--- a/lib/entities/payroll_employee.js
+++ b/lib/entities/payroll_employee.js
@@ -145,14 +145,14 @@ var Employee = Entity.extend(EmployeeSchema, {
     },
     fromXmlObj: function(obj) {
         var self = this;
-        _.extend(self, _.omit(obj, 'SalaryAndWages', 'WorkLocations', 'PaymentMethod', 'PayTemplate', 'OpeningBalances'));
+        Object.assign(self, _.omit(obj, 'SalaryAndWages', 'WorkLocations', 'PaymentMethod', 'PayTemplate', 'OpeningBalances'));
         if (obj.SalaryAndWages)
             this.extractArray(obj.SalaryAndWages.SalaryAndWage, this.SalaryAndWages);
         if (obj.WorkLocations)
             this.extractArray(obj.WorkLocations.WorkLocation, this.WorkLocations);
 
         if (obj.PaymentMethod) {
-            _.extend(this.PaymentMethod, _.pick(obj.PaymentMethod, 'PaymentMethodType'));
+            Object.assign(this.PaymentMethod, _.pick(obj.PaymentMethod, 'PaymentMethodType'));
             if (obj.PaymentMethod.BankAccounts)
                 this.extractArray(obj.PaymentMethod.BankAccounts, this.PaymentMethod.BankAccounts);
         }

--- a/lib/entities/timesheet.js
+++ b/lib/entities/timesheet.js
@@ -39,7 +39,7 @@ var Timesheet = Entity.extend(TimesheetSchema, {
     fromXmlObj: function (obj)
     {
         var self = this;
-        _.extend(self, _.omit(obj, 'TimesheetLines'));
+        Object.assign(self, _.omit(obj, 'TimesheetLines'));
         if (obj.TimesheetLines) {
             var items = this.application.asArray(obj.TimesheetLines.TimesheetLine);
             _.each(items,function(item)
@@ -60,7 +60,7 @@ var Timesheet = Entity.extend(TimesheetSchema, {
     toXml: function ()
     {
         var timesheet = _.omit(this.toObject(), 'TimesheetLines');
-        _.extend(timesheet, { TimesheetLines: []});
+        Object.assign(timesheet, { TimesheetLines: []});
         _.forEach(this.TimesheetLines, function(timesheetline)
         {
             timesheet.TimesheetLines.push({ TimesheetLine: _.pick(timesheetline.toObject(),'EarningsTypeID','TrackingItemID')});

--- a/lib/entities/trackingcategory.js
+++ b/lib/entities/trackingcategory.js
@@ -24,7 +24,7 @@ var TrackingCategory = Entity.extend(TrackingCategorySchema, {
     },
     fromXmlObj: function(obj) {
         var self = this;
-        _.extend(self, _.omit(obj, 'Options'));
+        Object.assign(self, _.omit(obj, 'Options'));
         if (obj.Options) {
             _.each(this.application.asArray(obj.Options.Option), function(option) {
                 self.Options.push(option);
@@ -36,7 +36,7 @@ var TrackingCategory = Entity.extend(TrackingCategorySchema, {
     toXml: function() {
         var trackingCategory = _.omit(this.toObject(), 'Options');
         // Options cannot be saved using this endpoint, they must use the specific /options endpoint
-        // _.extend(trackingCategory, { Options: [] });
+        // Object.assign(trackingCategory, { Options: [] });
         // _.forEach(this.Options, function(option) {
         //     trackingCategory.Options.push({ Option: option.toObject() })
         // })

--- a/lib/entity_helpers/accounts.js
+++ b/lib/entity_helpers/accounts.js
@@ -6,7 +6,7 @@ var _ = require('lodash'),
 
 var Accounts = EntityHelper.extend({
     constructor: function(application, options) {
-        EntityHelper.call(this, application, _.extend({ entityName: 'Account', entityPlural: 'Accounts' }, options));
+        EntityHelper.call(this, application, Object.assign({ entityName: 'Account', entityPlural: 'Accounts' }, options));
     },
     newAccount: function(data, options) {
         return new Account(this.application, data, options)

--- a/lib/entity_helpers/attachments.js
+++ b/lib/entity_helpers/attachments.js
@@ -6,7 +6,7 @@ var _ = require('lodash'),
 
 var Attachments = EntityHelper.extend({
     constructor: function(application, options) {
-        EntityHelper.call(this, application, _.extend({ entityName: 'Attachment', entityPlural: 'Attachments' }, options));
+        EntityHelper.call(this, application, Object.assign({ entityName: 'Attachment', entityPlural: 'Attachments' }, options));
     },
     newAttachment: function(data, options) {
         return new Attachment(this.application, data, options)
@@ -19,7 +19,7 @@ var Attachments = EntityHelper.extend({
             })
     },
     getAttachments: function(ownerPath, options) {
-        var clonedOptions = _.extend({}, options, { path: ownerPath + '/Attachments' });
+        var clonedOptions = Object.assign({}, options, { path: ownerPath + '/Attachments' });
         clonedOptions.entityConstructor = function(data) { return self.newAttachment(data) };
         return this.getEntities(clonedOptions);
     }

--- a/lib/entity_helpers/banktransactions.js
+++ b/lib/entity_helpers/banktransactions.js
@@ -6,7 +6,7 @@ var _ = require('lodash'),
 
 var BankTransactions = EntityHelper.extend({
     constructor: function(application, options) {
-        EntityHelper.call(this, application, _.extend({ entityName: 'BankTransaction', entityPlural: 'BankTransactions' }, options));
+        EntityHelper.call(this, application, Object.assign({ entityName: 'BankTransaction', entityPlural: 'BankTransactions' }, options));
     },
     newBankTransaction: function(data, options) {
         return new BankTransaction(this.application, data, options)

--- a/lib/entity_helpers/banktransfers.js
+++ b/lib/entity_helpers/banktransfers.js
@@ -6,7 +6,7 @@ var _ = require('lodash'),
 
 var BankTransfers = EntityHelper.extend({
     constructor: function(application, options) {
-        EntityHelper.call(this, application, _.extend({ entityName: 'BankTransfer', entityPlural: 'BankTransfers' }, options));
+        EntityHelper.call(this, application, Object.assign({ entityName: 'BankTransfer', entityPlural: 'BankTransfers' }, options));
     },
     newBankTransfer: function(data, options) {
         return new BankTransfer(this.application, data, options)

--- a/lib/entity_helpers/contacts.js
+++ b/lib/entity_helpers/contacts.js
@@ -6,7 +6,7 @@ var _ = require('lodash'),
 
 var Contacts = EntityHelper.extend({
     constructor: function(application, options) {
-        EntityHelper.call(this, application, _.extend({ entityName: 'Contact', entityPlural: 'Contacts' }, options));
+        EntityHelper.call(this, application, Object.assign({ entityName: 'Contact', entityPlural: 'Contacts' }, options));
     },
     newContact: function(data, options) {
         return new Contact(this.application, data, options)

--- a/lib/entity_helpers/entity_helper.js
+++ b/lib/entity_helpers/entity_helper.js
@@ -18,7 +18,7 @@ function EntityHelper(application, options) {
 }
 EntityHelper.extend = extend;
 
-_.extend(EntityHelper.prototype, {
+Object.assign(EntityHelper.prototype, {
     saveEntities: function(entities, options) {
         logger.debug('EntityHelper::saveEntities');
         options = options || {};

--- a/lib/entity_helpers/invoices.js
+++ b/lib/entity_helpers/invoices.js
@@ -6,7 +6,7 @@ var _ = require('lodash'),
 
 var Invoices = EntityHelper.extend({
     constructor: function(application, options) {
-        EntityHelper.call(this, application, _.extend({ entityName: 'Invoice', entityPlural: 'Invoices' }, options));
+        EntityHelper.call(this, application, Object.assign({ entityName: 'Invoice', entityPlural: 'Invoices' }, options));
     },
     newInvoice: function(data, options) {
         return new Invoice(this.application, data, options)

--- a/lib/entity_helpers/items.js
+++ b/lib/entity_helpers/items.js
@@ -6,7 +6,7 @@ var _ = require('lodash'),
 
 var Items = EntityHelper.extend({
     constructor: function(application, options) {
-        EntityHelper.call(this, application, _.extend({ entityName: 'Item', entityPlural: 'Items' }, options));
+        EntityHelper.call(this, application, Object.assign({ entityName: 'Item', entityPlural: 'Items' }, options));
     },
     newItem: function(data, options) {
         return new Item(this.application, data, options)

--- a/lib/entity_helpers/organisations.js
+++ b/lib/entity_helpers/organisations.js
@@ -6,7 +6,7 @@ var _ = require('lodash'),
 
 var Organisations = EntityHelper.extend({
     constructor: function(application, options) {
-        EntityHelper.call(this, application, _.extend({ entityName: 'Organisation', entityPlural: 'Organisations' }, options));
+        EntityHelper.call(this, application, Object.assign({ entityName: 'Organisation', entityPlural: 'Organisations' }, options));
     },
     getOrganisations: function(options, callback) {
         var self = this;

--- a/lib/entity_helpers/payitems.js
+++ b/lib/entity_helpers/payitems.js
@@ -12,7 +12,7 @@ var _ = require('lodash')
 var PayItems = EntityHelper.extend({
     constructor: function (application, options)
     {
-        EntityHelper.call(this, application, _.extend({
+        EntityHelper.call(this, application, Object.assign({
             entityPlural: 'PayItems', path: 'Payitems'}, options));
     },
     newPayItems: function(data, options)
@@ -42,7 +42,7 @@ var PayItems = EntityHelper.extend({
     getPayItems: function (options)
     {
         var self = this;
-        var clonedOptions = _.extend({},options, { api: 'payroll'});
+        var clonedOptions = Object.assign({},options, { api: 'payroll'});
         clonedOptions.entityConstructor = function(data) { return self.newPayItems(data)};
         return this.getEntities(clonedOptions)
     }

--- a/lib/entity_helpers/payments.js
+++ b/lib/entity_helpers/payments.js
@@ -6,7 +6,7 @@ var _ = require('lodash'),
 
 var Payments = EntityHelper.extend({
     constructor: function(application, options) {
-        EntityHelper.call(this, application, _.extend({ entityName: 'Payment', entityPlural: 'Payments' }, options));
+        EntityHelper.call(this, application, Object.assign({ entityName: 'Payment', entityPlural: 'Payments' }, options));
     },
     createPayment: function(data, options) {
         return new Payment(this.application, data, options);

--- a/lib/entity_helpers/payroll_employees.js
+++ b/lib/entity_helpers/payroll_employees.js
@@ -6,7 +6,7 @@ var _ = require('lodash'),
 
 var Employees = EntityHelper.extend({
     constructor: function(application, options) {
-        EntityHelper.call(this, application, _.extend({ entityName: 'Employee', entityPlural: 'Employees' }, options));
+        EntityHelper.call(this, application, Object.assign({ entityName: 'Employee', entityPlural: 'Employees' }, options));
     },
     newEmployee: function(data, options) {
         return new Employee(this.application, data, options)
@@ -23,7 +23,7 @@ var Employees = EntityHelper.extend({
     },
     getEmployees: function(options) {
         var self = this;
-        var clonedOptions = _.extend({}, options, { api: 'payroll' });
+        var clonedOptions = Object.assign({}, options, { api: 'payroll' });
         clonedOptions.entityConstructor = function(data) { return self.newEmployee(data) };
         return this.getEntities(clonedOptions)
     }

--- a/lib/entity_helpers/taxrates.js
+++ b/lib/entity_helpers/taxrates.js
@@ -6,7 +6,7 @@ var _ = require('lodash'),
 
 var TaxRates = EntityHelper.extend({
     constructor: function(application, options) {
-        EntityHelper.call(this, application, _.extend({ entityName: 'TaxRate', entityPlural: 'TaxRates' }, options));
+        EntityHelper.call(this, application, Object.assign({ entityName: 'TaxRate', entityPlural: 'TaxRates' }, options));
     },
     newTaxRate: function(data, options) {
         return new TaxRate(this.application, data, options);

--- a/lib/entity_helpers/timesheets.js
+++ b/lib/entity_helpers/timesheets.js
@@ -7,7 +7,7 @@ var _ = require('lodash')
 var Timesheets = EntityHelper.extend({
     constructor: function (application, options)
     {
-        EntityHelper.call(this, application, _.extend({ entityName:'Timesheet', entityPlural:'Timesheets'}, options));
+        EntityHelper.call(this, application, Object.assign({ entityName:'Timesheet', entityPlural:'Timesheets'}, options));
     },
     newTimesheet: function (data, options)
     {
@@ -23,12 +23,12 @@ var Timesheets = EntityHelper.extend({
     },
     saveTimesheets: function (timesheets, options)
     {
-        return this.saveEntities(timesheets, _.extend({},options,{ method: 'post',api: 'payroll'}));
+        return this.saveEntities(timesheets, Object.assign({},options,{ method: 'post',api: 'payroll'}));
     },
     getTimesheets: function (options)
     {
         var self = this;
-        var clonedOptions = _.extend({},options, { api: 'payroll'});
+        var clonedOptions = Object.assign({},options, { api: 'payroll'});
         clonedOptions.entityConstructor = function(data) { return self.newTimesheet(data)};
         return this.getEntities(clonedOptions)
     }

--- a/lib/entity_helpers/trackingcategories.js
+++ b/lib/entity_helpers/trackingcategories.js
@@ -7,7 +7,7 @@ var _ = require('lodash'),
 
 var TrackingCategories = EntityHelper.extend({
     constructor: function(application, options) {
-        EntityHelper.call(this, application, _.extend({ entityName: 'TrackingCategory', entityPlural: 'TrackingCategories' }, options));
+        EntityHelper.call(this, application, Object.assign({ entityName: 'TrackingCategory', entityPlural: 'TrackingCategories' }, options));
     },
     newTrackingCategory: function(data, options) {
         return new TrackingCategory(this.application, data, options)

--- a/lib/entity_helpers/users.js
+++ b/lib/entity_helpers/users.js
@@ -6,7 +6,7 @@ var _ = require('lodash'),
 
 var Users = EntityHelper.extend({
     constructor: function(application, options) {
-        EntityHelper.call(this, application, _.extend({ entityName: 'User', entityPlural: 'Users' }, options));
+        EntityHelper.call(this, application, Object.assign({ entityName: 'User', entityPlural: 'Users' }, options));
     },
     newUser: function(data, options) {
         return new User(this.application, data, options)

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,5 +1,4 @@
 ﻿var log4js = require('log4js'),
-    fs = require('fs'),
     path = require('path'),
     dateFormat = require('dateformat'),
     util = require('util'),

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -33,7 +33,7 @@ Logger.prototype = {
         }
         log4js.configure({ appenders: appenders, replaceConsole: false });
         this.setLevel(settings.level);*/
-        _.extend(this.settings, settings);
+        Object.assign(this.settings, settings);
 
     },
     init: function(settings) {

--- a/lib/misc/extend.js
+++ b/lib/misc/extend.js
@@ -19,7 +19,7 @@ module.exports = function (protoProps, staticProps)
         }
 
         // Inherit class (static) properties from parent.
-        _.extend(child, parent);
+        Object.assign(child, parent);
 
         // Set the prototype chain to inherit from `parent`, without calling
         // `parent`'s constructor function.
@@ -30,7 +30,7 @@ module.exports = function (protoProps, staticProps)
         // if supplied.
         if (protoProps)
         {
-            _.extend(child.prototype, protoProps);
+            Object.assign(child.prototype, protoProps);
 
             // Copy the properties over onto the new prototype
             for (var name in protoProps)
@@ -75,7 +75,7 @@ module.exports = function (protoProps, staticProps)
         }
 
         // Add static properties to the constructor function, if supplied.
-        if (staticProps) _.extend(child, staticProps);
+        if (staticProps) Object.assign(child, staticProps);
 
         // Correctly set child's `prototype.constructor`.
         child.prototype.constructor = child;

--- a/lib/oauth/oauth.js
+++ b/lib/oauth/oauth.js
@@ -3,7 +3,6 @@ var crypto = require('crypto'),
     http = require('http'),
     https = require('https'),
     URL = require('url'),
-    fs = require('fs'),
     querystring = require('querystring'),
     OAuthUtils = require('./_utils'),
     _ = require('lodash');

--- a/lib/payroll.js
+++ b/lib/payroll.js
@@ -23,12 +23,12 @@ function Payroll(application, options)
 }
 
 // Static
-_.extend(Payroll, {
+Object.assign(Payroll, {
 
 })
 
 // Instance
-_.extend(Payroll.prototype, {
+Object.assign(Payroll.prototype, {
 
 
 })

--- a/lib/schemaobject/schemaobject.js
+++ b/lib/schemaobject/schemaobject.js
@@ -611,7 +611,7 @@ var Tracking = function(instance) {
     this._instance = instance;
 }
 
-_.extend(Tracking.prototype, {
+Object.assign(Tracking.prototype, {
     clear: function() {
         var self = this;
         _.each(this._instance._schema, function(properties, index) {

--- a/test/accountingtests.js
+++ b/test/accountingtests.js
@@ -19,7 +19,7 @@ var organisationCountry = '';
 var APPTYPE = metaConfig.APPTYPE;
 var config = metaConfig[APPTYPE.toLowerCase()];
 
-if (config.PrivateKeyPath && !config.PrivateKey) config.PrivateKey = fs.readFileSync(config.PrivateKeyPath);
+if (config.privateKeyPath && !config.privateKey) config.privateKey = fs.readFileSync(config.privateKeyPath);
 
 before('init instance and set options', function(done) {
     switch (APPTYPE) {
@@ -97,8 +97,8 @@ describe('get access for public or partner application', function() {
 
             describe('submits form', function() {
                 var options = {
-                  XeroUsername: config.XeroUsername,
-                  XeroPassword: config.XeroPassword
+                  XeroUsername: config.xeroUsername,
+                  XeroPassword: config.xeroPassword
                 };
 
                 it('should login', function(done) {


### PR DESCRIPTION
s/_.extend/Object.assign/g

This is personal preference rather than obvious technical superiority. They both do the same thing.

Modern JS supplies Object.assign, though, so we might as well use it. It's one less piece of custom API for an incoming developer to understand, and it saves confusion with the custom `extend` function being used elsewhere in the codebase.