### PR TITLE
Add refresh token functionality

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -8,7 +8,8 @@ var _ = require('lodash'),
     Core = require('./core'),
     qs = require('querystring'),
     Payroll = require('./payroll'),
-    xml2js = require('xml2js')
+    xml2js = require('xml2js'),
+    events = new require('events');
 
 function Batch(application) {
     logger.debug('Batch::constructor');
@@ -45,6 +46,7 @@ function Application(options) {
 
     var core = new Core(this);
     var payroll = new Payroll(this);
+
     Object.defineProperties(this, {
         core: {
             get: function() {
@@ -81,6 +83,8 @@ Object.assign(Application.prototype, {
         if (this.options["runscopeBucketId"] && this.options["runscopeBucketId"] !== "") {
             this.options.baseUrl = "https://api-xero-com-" + this.options["runscopeBucketId"] + ".runscope.net";
         }
+
+        this.eventEmitter = new events.EventEmitter();
     },
     post: function(path, body, options, callback) {
         return this.putOrPost('post', path, body, options, callback);
@@ -474,9 +478,10 @@ Object.assign(Application.prototype, {
          */
 
         var expiry = new Date(this.options.tokenExpiry),
-            checkTime = addMinutes(new Date(), 3);
+            checkTime = addMinutes(new Date(), 29);
 
         if (checkTime >= expiry) {
+            logger.debug("Refreshing Access Token");
             return this.refreshAccessToken();
         } else {
             return Promise.resolve();
@@ -554,7 +559,7 @@ var RequireAuthorizationApplication = Application.extend({
                         accessSecret: results.oauth_token_secret,
                         sessionHandle: results.oauth_session_handle,
                         tokenExpiry: exp.toString()
-                    });
+                    }, false);
                     resolve({ results: results });
                 }
                 callback && callback.apply(callback, arguments);
@@ -576,7 +581,7 @@ var RequireAuthorizationApplication = Application.extend({
                         accessSecret: results.oauth_token_secret,
                         sessionHandle: results.oauth_session_handle,
                         tokenExpiry: exp.toString()
-                    });
+                    }, true);
                     resolve({ results: results });
                 }
 
@@ -588,11 +593,21 @@ var RequireAuthorizationApplication = Application.extend({
         var q = Object.assign({}, { oauth_token: requestToken }, other);
         return this.options.baseUrl + this.options.authorizeUrl + '?' + querystring.stringify(q);
     },
-    setOptions: function(options) {
-        this.options.accessToken = options.accessToken;
-        this.options.accessSecret = options.accessSecret;
-        this.options.sessionHandle = options.sessionHandle;
-        this.options.tokenExpiry = options.tokenExpiry;
+    setOptions: function(options, emitThisEvent) {
+        logger.debug("Setting options");
+        options.accessToken ? this.options.accessToken = options.accessToken : false;
+        options.accessSecret ? this.options.accessSecret = options.accessSecret : false;
+        options.sessionHandle ? this.options.sessionHandle = options.sessionHandle : false;
+        options.tokenExpiry ? this.options.tokenExpiry = options.tokenExpiry : false;
+
+        if (emitThisEvent && this.eventEmitter) {
+            logger.debug("Emitting event");
+            try {
+                this.eventEmitter.emit('xeroTokenUpdate', options);
+            } catch (e) {
+                logger.error(e);
+            }
+        }
     }
 });
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -98,55 +98,73 @@ Object.assign(Application.prototype, {
         options = options || {};
         return new Promise(function(resolve, reject) {
             var params = {};
-            if (options.summarizeErrors === false)
-                params.summarizeErrors = false;
 
-            //Added to support more than 2dp being added.
-            if (options.unitdp)
-                params.unitdp = options.unitdp;
+            self.checkExpiry()
+                .then(function() {
+                    if (options.summarizeErrors === false)
+                        params.summarizeErrors = false;
 
-            var endPointUrl = options.api === 'payroll' ? self.options.payrollAPIEndPointUrl : self.options.coreAPIEndPointUrl;
-            var url = self.options.baseUrl + endPointUrl + path;
-            if (!_.isEmpty(params))
-                url += '?' + querystring.stringify(params);
+                    //Added to support more than 2dp being added.
+                    if (options.unitdp)
+                        params.unitdp = options.unitdp;
 
-            self.oa[method](url, self.options.accessToken, self.options.accessSecret, { xml: body }, function(err, data, res) {
+                    var endPointUrl = options.api === 'payroll' ? self.options.payrollAPIEndPointUrl : self.options.coreAPIEndPointUrl;
+                    var url = self.options.baseUrl + endPointUrl + path;
+                    if (!_.isEmpty(params))
+                        url += '?' + querystring.stringify(params);
 
-                if (err && data && data.indexOf('oauth_problem') >= 0) {
-                    var errObj = new Error(method.toUpperCase() + ' call failed with: ' + err.statusCode);
-                    errObj.data = qs.parse(data);
-                    reject(errObj);
-                    callback && callback(errObj);
-                    return;
-                }
+                    self.oa[method](url, self.options.accessToken, self.options.accessSecret, { xml: body }, function(err, data, res) {
 
-                self.xml2js(data)
-                    .then(function(obj) {
-                        if (err) {
-                            var exception = "";
-                            if (obj.ApiException)
-                                exception = obj.ApiException;
-                            else if (obj.Response.ErrorNumber)
-                                exception = obj.Response;
-                            var errObj = new Error(method.toUpperCase() + ' call failed with: ' + err.statusCode + ' and exception: ' + JSON.stringify(exception, null, 2));
+                        if (err && data && data.indexOf('oauth_problem') >= 0) {
+                            var errObj = new Error(method.toUpperCase() + ' call failed with: ' + err.statusCode);
+                            errObj.data = qs.parse(data);
                             reject(errObj);
                             callback && callback(errObj);
-                        } else {
-                            var ret = { response: obj.Response, res: res };
-                            if (options.entityConstructor) {
-                                ret.entities = self.convertEntities(obj.Response, options);
-                            }
-                            resolve(ret);
-                            callback && callback(null, obj, res, ret.entities);
+                            return;
                         }
 
-                    })
-                    .catch(function(err) {
-                        logger.error(err);
-                        throw err;
-                    })
+                        self.xml2js(data)
+                            .then(function(obj) {
+                                if (err) {
+                                    var exception = "";
+                                    if (obj.ApiException)
+                                        exception = obj.ApiException;
+                                    else if (obj.Response.ErrorNumber)
+                                        exception = obj.Response;
+                                    var errObj = new Error(method.toUpperCase() + ' call failed with: ' + err.statusCode + ' and exception: ' + JSON.stringify(exception, null, 2));
+                                    reject(errObj);
+                                    callback && callback(errObj);
+                                } else {
+                                    var ret = { response: obj.Response, res: res };
+                                    if (options.entityConstructor) {
+                                        ret.entities = self.convertEntities(obj.Response, options);
+                                    }
+                                    resolve(ret);
+                                    callback && callback(null, obj, res, ret.entities);
+                                }
 
-            });
+                            })
+                            .catch(function(err) {
+                                logger.error(err);
+                                throw err;
+                            })
+
+                    });
+                })
+                .catch(function(err) {
+                    logger.debug(err);
+                    if (err && err.data) {
+                        var dataParts = qs.parse(err.data);
+
+                        var errObj = new Error(method.toUpperCase() + ' call failed with: ' + err.statusCode);
+                        errObj.data = dataParts;
+                        reject(errObj);
+                        callback && callback(errObj);
+                        return;
+                    }
+                });
+
+
         });
     },
     delete: function(path, options, callback) {
@@ -157,42 +175,57 @@ Object.assign(Application.prototype, {
             var endPointUrl = options.api === 'payroll' ? self.options.payrollAPIEndPointUrl : self.options.coreAPIEndPointUrl;
             var url = self.options.baseUrl + endPointUrl + path;
 
-            self.oa.delete(url, self.options.accessToken, self.options.accessSecret, function(err, data, res) {
-                if (options.stream && !err) {
-                    // Already done
-                    return resolve();
-                }
-                if (err && data && data.indexOf('oauth_problem') >= 0) {
-                    var errObj = new Error('DELETE call failed with: ' + err.statusCode);
-                    errObj.data = qs.parse(data);
-                    reject(errObj);
-                    callback && callback(errObj);
-                    return;
-                }
+            self.checkExpiry()
+                .then(function() {
+                    self.oa.delete(url, self.options.accessToken, self.options.accessSecret, function(err, data, res) {
+                        if (options.stream && !err) {
+                            // Already done
+                            return resolve();
+                        }
+                        if (err && data && data.indexOf('oauth_problem') >= 0) {
+                            var errObj = new Error('DELETE call failed with: ' + err.statusCode);
+                            errObj.data = qs.parse(data);
+                            reject(errObj);
+                            callback && callback(errObj);
+                            return;
+                        }
 
-                if (err) {
-                    var errObj = new Error('DELETE call failed with: ' + err.statusCode + ' and message: ' + err.data);
-                    reject(errObj);
-                    callback && callback(errObj);
-                    return;
-                }
+                        if (err) {
+                            var errObj = new Error('DELETE call failed with: ' + err.statusCode + ' and message: ' + err.data);
+                            reject(errObj);
+                            callback && callback(errObj);
+                            return;
+                        }
 
-                //Some delete operations don't return any content (e.g. HTTP204) so simply resolve the promise
-                if (!data || data === "") {
-                    return resolve();
-                }
+                        //Some delete operations don't return any content (e.g. HTTP204) so simply resolve the promise
+                        if (!data || data === "") {
+                            return resolve();
+                        }
 
-                self.xml2js(data)
-                    .then(function(obj) {
-                        var ret = { response: obj.Response, res: res };
-                        resolve(ret);
-                        callback && callback(null, obj, res);
-                    })
-                    .catch(function(err) {
-                        logger.error(err);
-                        throw err;
-                    })
-            }, { stream: options.stream });
+                        self.xml2js(data)
+                            .then(function(obj) {
+                                var ret = { response: obj.Response, res: res };
+                                resolve(ret);
+                                callback && callback(null, obj, res);
+                            })
+                            .catch(function(err) {
+                                logger.error(err);
+                                throw err;
+                            })
+                    }, { stream: options.stream });
+                })
+                .catch(function(err) {
+                    logger.debug(err);
+                    if (err && err.data) {
+                        var dataParts = qs.parse(err.data);
+
+                        var errObj = new Error('DELETE call failed with: ' + err.statusCode);
+                        errObj.data = dataParts;
+                        reject(errObj);
+                        callback && callback(errObj);
+                        return;
+                    }
+                });
         });
     },
     get: function(path, options, callback) {
@@ -213,6 +246,18 @@ Object.assign(Application.prototype, {
                         getResource(options.pager.start || 1)
                     else
                         getResource();
+                })
+                .catch(function(err) {
+                    logger.debug(err);
+                    if (err && err.data) {
+                        var dataParts = qs.parse(err.data);
+
+                        var errObj = new Error('GET call failed with: ' + err.statusCode);
+                        errObj.data = dataParts;
+                        reject(errObj);
+                        callback && callback(errObj);
+                        return;
+                    }
                 });
 
             function getResource(offset) {
@@ -418,14 +463,27 @@ Object.assign(Application.prototype, {
         return obj;
     },
     checkExpiry: function() {
-        var d1 = new Date(this.options.tokenExpiry),
-            d2 = new Date();
 
-        if (d2 > d1) {
+        /**
+         * CheckExpiry is a helper function that will compare the current token expiry to the current time.
+         * 
+         * As there is potential for a time difference, instead of waiting all the way until the current time
+         * has passed the expiry time, we instead add 3 minutes to the current time, and use that as a comparison.
+         * 
+         * This ensures that if the token is 'nearing' the expiry, it'll attempt to be refreshed.
+         */
+
+        var expiry = new Date(this.options.tokenExpiry),
+            checkTime = addMinutes(new Date(), 3);
+
+        if (checkTime >= expiry) {
             return this.refreshAccessToken();
         } else {
-            logger.debug("Dates are fine, no need for refresh");
             return Promise.resolve();
+        }
+
+        function addMinutes(date, minutes) {
+            return new Date(date.getTime() + minutes * 60000);
         }
     }
 })
@@ -490,13 +548,12 @@ var RequireAuthorizationApplication = Application.extend({
                     reject(err);
                 else {
                     var exp = new Date();
-                    exp.setSeconds(exp.getSeconds() + results.oauth_expires_in);
-
+                    exp.setTime(exp.getTime() + (results.oauth_expires_in * 1000));
                     self.setOptions({
                         accessToken: results.oauth_token,
                         accessSecret: results.oauth_token_secret,
                         sessionHandle: results.oauth_session_handle,
-                        tokenExpiry: exp.toISOString()
+                        tokenExpiry: exp.toString()
                     });
                     resolve({ results: results });
                 }
@@ -513,13 +570,12 @@ var RequireAuthorizationApplication = Application.extend({
                     reject(err);
                 else {
                     var exp = new Date();
-                    exp.setSeconds(exp.getSeconds() + results.oauth_expires_in);
-
+                    exp.setTime(exp.getTime() + (results.oauth_expires_in * 1000));
                     self.setOptions({
                         accessToken: results.oauth_token,
                         accessSecret: results.oauth_token_secret,
                         sessionHandle: results.oauth_session_handle,
-                        tokenExpiry: exp.toISOString()
+                        tokenExpiry: exp.toString()
                     });
                     resolve({ results: results });
                 }
@@ -537,9 +593,6 @@ var RequireAuthorizationApplication = Application.extend({
         this.options.accessSecret = options.accessSecret;
         this.options.sessionHandle = options.sessionHandle;
         this.options.tokenExpiry = options.tokenExpiry;
-
-        console.log("options set!");
-        console.log(this.options);
     }
 });
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -478,7 +478,7 @@ Object.assign(Application.prototype, {
          */
 
         var expiry = new Date(this.options.tokenExpiry),
-            checkTime = addMinutes(new Date(), 29);
+            checkTime = addMinutes(new Date(), 3);
 
         if (checkTime >= expiry) {
             logger.debug("Refreshing Access Token");

--- a/lib/application.js
+++ b/lib/application.js
@@ -243,11 +243,7 @@ Object.assign(Application.prototype, {
                         return resolve();
                     }
                     if (err && data) {
-                        var dataParts;
-                        if (_.isObject(data))
-                            dataParts = qs.parse(data);
-                        else
-                            dataParts = data;
+                        var dataParts = qs.parse(data);
 
                         var errObj = new Error('GET call failed with: ' + err.statusCode);
                         errObj.data = dataParts;
@@ -491,6 +487,7 @@ var RequireAuthorizationApplication = Application.extend({
     setOptions: function(options) {
         this.options.accessToken = options.accessToken;
         this.options.accessSecret = options.accessSecret;
+        this.options.sessionHandle = options.sessionHandle;
     }
 });
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -207,10 +207,13 @@ Object.assign(Application.prototype, {
             if (options.format)
                 self.oa._headers['Accept'] = 'application/' + options.format;
 
-            if (options.pager)
-                getResource(options.pager.start || 1)
-            else
-                getResource();
+            self.checkExpiry()
+                .then(function() {
+                    if (options.pager)
+                        getResource(options.pager.start || 1)
+                    else
+                        getResource();
+                });
 
             function getResource(offset) {
                 var endPointUrl = options.api === 'payroll' ? self.options.payrollAPIEndPointUrl : self.options.coreAPIEndPointUrl;
@@ -413,6 +416,17 @@ Object.assign(Application.prototype, {
         var builder = new xml2js.Builder({ rootName: rootName, headless: true });
         var obj = builder.buildObject(obj);
         return obj;
+    },
+    checkExpiry: function() {
+        var d1 = new Date(this.options.tokenExpiry),
+            d2 = new Date();
+
+        if (d2 > d1) {
+            return this.refreshAccessToken();
+        } else {
+            logger.debug("Dates are fine, no need for refresh");
+            return Promise.resolve();
+        }
     }
 })
 
@@ -475,7 +489,15 @@ var RequireAuthorizationApplication = Application.extend({
                 if (err)
                     reject(err);
                 else {
-                    self.setOptions({ accessToken: results.oauth_token, accessSecret: results.oauth_token_secret, sessionHandle: results.oauth_session_handle });
+                    var exp = new Date();
+                    exp.setSeconds(exp.getSeconds() + results.oauth_expires_in);
+
+                    self.setOptions({
+                        accessToken: results.oauth_token,
+                        accessSecret: results.oauth_token_secret,
+                        sessionHandle: results.oauth_session_handle,
+                        tokenExpiry: exp.toISOString()
+                    });
                     resolve({ results: results });
                 }
                 callback && callback.apply(callback, arguments);
@@ -490,7 +512,15 @@ var RequireAuthorizationApplication = Application.extend({
                 if (err)
                     reject(err);
                 else {
-                    self.setOptions({ accessToken: results.oauth_token, accessSecret: results.oauth_token_secret, sessionHandle: results.oauth_session_handle });
+                    var exp = new Date();
+                    exp.setSeconds(exp.getSeconds() + results.oauth_expires_in);
+
+                    self.setOptions({
+                        accessToken: results.oauth_token,
+                        accessSecret: results.oauth_token_secret,
+                        sessionHandle: results.oauth_session_handle,
+                        tokenExpiry: exp.toISOString()
+                    });
                     resolve({ results: results });
                 }
 
@@ -506,6 +536,10 @@ var RequireAuthorizationApplication = Application.extend({
         this.options.accessToken = options.accessToken;
         this.options.accessSecret = options.accessSecret;
         this.options.sessionHandle = options.sessionHandle;
+        this.options.tokenExpiry = options.tokenExpiry;
+
+        console.log("options set!");
+        console.log(this.options);
     }
 });
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -467,15 +467,33 @@ var RequireAuthorizationApplication = Application.extend({
             });
         });
     },
-    getAccessToken: function(token, secret, verifier, callback, options) {
+    setAccessToken: function(token, secret, verifier, callback, options) {
         var self = this;
 
         return new Promise(function(resolve, reject) {
-            self.oa.getOAuthAccessToken(token, secret, verifier, function(err, token, secret, results) {
+            self.oa.getOAuthAccessToken(token, secret, verifier, function(err, results) {
                 if (err)
                     reject(err);
-                else
-                    resolve({ token: token, secret: secret, results: results });
+                else {
+                    self.setOptions({ accessToken: results.oauth_token, accessSecret: results.oauth_token_secret, sessionHandle: results.oauth_session_handle });
+                    resolve({ results: results });
+                }
+                callback && callback.apply(callback, arguments);
+            })
+        });
+    },
+    refreshAccessToken: function(callback, options) {
+        var self = this;
+
+        return new Promise(function(resolve, reject) {
+            self.oa.getOAuthAccessToken(self.options.accessToken, self.options.accessSecret, { oauth_session_handle: self.options.sessionHandle }, function(err, results) {
+                if (err)
+                    reject(err);
+                else {
+                    self.setOptions({ accessToken: results.oauth_token, accessSecret: results.oauth_token_secret, sessionHandle: results.oauth_session_handle });
+                    resolve({ results: results });
+                }
+
                 callback && callback.apply(callback, arguments);
             })
         });

--- a/lib/oauth/oauth.js
+++ b/lib/oauth/oauth.js
@@ -461,6 +461,8 @@ exports.OAuth.prototype.getOAuthAccessToken = function(oauth_token, oauth_token_
     var extraParams = {};
     if (typeof oauth_verifier == "function") {
         callback = oauth_verifier;
+    } else if (typeof oauth_verifier == "object") {
+        extraParams.oauth_session_handle = oauth_verifier.oauth_session_handle;
     } else {
         extraParams.oauth_verifier = oauth_verifier;
     }
@@ -469,11 +471,7 @@ exports.OAuth.prototype.getOAuthAccessToken = function(oauth_token, oauth_token_
         if (error) callback(error);
         else {
             var results = querystring.parse(data);
-            var oauth_access_token = results["oauth_token"];
-            delete results["oauth_token"];
-            var oauth_access_token_secret = results["oauth_token_secret"];
-            delete results["oauth_token_secret"];
-            callback(null, oauth_access_token, oauth_access_token_secret, results);
+            callback(null, results);
         }
     })
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "dateformat": "~1.0.7-1.2.3",
+    "events": "^1.1.1",
     "lodash": "~2.4.1",
     "log4js": "~0.6.9",
     "lru-cache": "^4.0.2",
@@ -39,6 +40,7 @@
     "mustache": "^2.3.0",
     "nodemailer": "",
     "nyc": "^10.1.2",
+    "sinon": "^1.17.7",
     "zombie": "^5.0.5",
     "zombie-phantom": "0.0.6"
   }

--- a/sample_app/index.js
+++ b/sample_app/index.js
@@ -123,6 +123,20 @@ function authorizedOperation(req, res, returnTo, callback) {
     }
 }
 
+function handleErr(err, req, res, returnTo) {
+    console.log(err);
+    if (err.data && err.data.oauth_problem && err.data.oauth_problem == "token_rejected") {
+        authorizeRedirect(req, res, returnTo);
+    } else {
+        res.redirect('error');
+    }
+}
+
+app.get('/error', function(req, res) {
+    console.log(req.query.error);
+    res.render('index', { error: req.query.error });
+})
+
 // Home Page
 app.get('/', function(req, res) {
     res.render('index', {
@@ -143,7 +157,7 @@ app.get('/access', function(req, res) {
                 res.redirect(returnTo || '/');
             })
             .catch(function(err) {
-                console.log(err);
+                handleErr(err, req, res, 'error');
             })
     }
 });
@@ -160,7 +174,7 @@ app.get('/organisations', function(req, res) {
                 });
             })
             .catch(function(err) {
-                console.log(err);
+                handleErr(err, req, res, 'organisations');
             })
     })
 });
@@ -176,6 +190,9 @@ app.get('/taxrates', function(req, res) {
                     }
                 });
             })
+            .catch(function(err) {
+                handleErr(err, req, res, 'taxrates');
+            })
     })
 });
 
@@ -189,6 +206,9 @@ app.get('/users', function(req, res) {
                         users: true
                     }
                 });
+            })
+            .catch(function(err) {
+                handleErr(err, req, res, 'users');
             })
     })
 });
@@ -205,21 +225,10 @@ app.get('/employees', function(req, res) {
                 });
             })
             .catch(function(err) {
-                console.log(err)
-                res.render('employees', {
-                    error: err,
-                    active: {
-                        employees: true
-                    }
-                })
+                handleErr(err, req, res, 'employees');
             })
     })
 });
-
-app.get('/error', function(req, res) {
-    console.log(req.query.error);
-    res.render('index', { error: req.query.error });
-})
 
 app.get('/contacts', function(req, res) {
     authorizedOperation(req, res, '/contacts', function(xeroClient) {
@@ -232,6 +241,9 @@ app.get('/contacts', function(req, res) {
                         contacts: true
                     }
                 });
+            })
+            .catch(function(err) {
+                handleErr(err, req, res, 'contacts');
             })
 
         function pagerCallback(err, response, cb) {
@@ -253,6 +265,9 @@ app.get('/banktransactions', function(req, res) {
                     }
                 });
             })
+            .catch(function(err) {
+                handleErr(err, req, res, 'banktransactions');
+            })
 
         function pagerCallback(err, response, cb) {
             bankTransactions.push.apply(bankTransactions, response.data);
@@ -272,6 +287,9 @@ app.get('/journals', function(req, res) {
                         journals: true
                     }
                 });
+            })
+            .catch(function(err) {
+                handleErr(err, req, res, 'journals');
             })
 
         function pagerCallback(err, response, cb) {
@@ -293,6 +311,9 @@ app.get('/banktransfers', function(req, res) {
                     }
                 });
             })
+            .catch(function(err) {
+                handleErr(err, req, res, 'banktransfers');
+            })
 
         function pagerCallback(err, response, cb) {
             bankTransfers.push.apply(bankTransfers, response.data);
@@ -312,6 +333,9 @@ app.get('/payments', function(req, res) {
                     }
                 });
             })
+            .catch(function(err) {
+                handleErr(err, req, res, 'payments');
+            })
     })
 });
 
@@ -326,6 +350,9 @@ app.get('/trackingcategories', function(req, res) {
                     }
                 });
             })
+            .catch(function(err) {
+                handleErr(err, req, res, 'trackingcategories');
+            })
     })
 });
 
@@ -339,6 +366,9 @@ app.get('/accounts', function(req, res) {
                         accounts: true
                     }
                 });
+            })
+            .catch(function(err) {
+                handleErr(err, req, res, 'accounts');
             })
     })
 });
@@ -356,43 +386,12 @@ app.get('/timesheets', function(req, res) {
                 });
             })
             .catch(function(err) {
-                console.log(err)
-                res.render('timesheets', {
-                    error: err,
-                    active: {
-                        timesheets: true
-                    }
-                })
+                handleErr(err, req, res, 'timesheets');
             })
     })
 });
 
-app.use('/createtimesheet', function(req, res) {
-    if (req.method == 'GET') {
-        return res.render('createtimesheet');
-    } else if (req.method == 'POST') {
-        authorizedOperation(req, res, '/createtimesheet', function(xeroClient) {
-            var timesheet = xeroClient.payroll.timesheets.newTimesheet({
-                EmployeeID: '065a115c-ba9c-4c03-b8e3-44c551ed8f21',
-                StartDate: new Date(2014, 8, 23),
-                EndDate: new Date(2014, 8, 29),
-                Status: 'Draft',
-                TimesheetLines: [{
-                    EarningsTypeID: 'a9ab82bf-c421-4840-b245-1df307c2127a',
-                    NumberOfUnits: [5, 0, 0, 0, 0, 0, 0]
-                }]
-            });
-            timesheet.save()
-                .then(function(ret) {
-                    res.render('createtimesheet', { timesheets: ret.entities })
-                })
-                .catch(function(err) {
-                    res.render('createtimesheet', { err: err })
-                })
 
-        })
-    }
-});
 
 
 app.get('/invoices', function(req, res) {
@@ -406,6 +405,9 @@ app.get('/invoices', function(req, res) {
                         invoices: true
                     }
                 });
+            })
+            .catch(function(err) {
+                handleErr(err, req, res, 'invoices');
             })
 
     })
@@ -421,6 +423,9 @@ app.get('/items', function(req, res) {
                         items: true
                     }
                 });
+            })
+            .catch(function(err) {
+                handleErr(err, req, res, 'items');
             })
 
     })
@@ -452,6 +457,33 @@ app.use('/createinvoice', function(req, res) {
                 })
                 .catch(function(err) {
                     res.render('createinvoice', { outcome: 'Error', err: err })
+                })
+
+        })
+    }
+});
+
+app.use('/createtimesheet', function(req, res) {
+    if (req.method == 'GET') {
+        return res.render('createtimesheet');
+    } else if (req.method == 'POST') {
+        authorizedOperation(req, res, '/createtimesheet', function(xeroClient) {
+            var timesheet = xeroClient.payroll.timesheets.newTimesheet({
+                EmployeeID: '065a115c-ba9c-4c03-b8e3-44c551ed8f21',
+                StartDate: new Date(2014, 8, 23),
+                EndDate: new Date(2014, 8, 29),
+                Status: 'Draft',
+                TimesheetLines: [{
+                    EarningsTypeID: 'a9ab82bf-c421-4840-b245-1df307c2127a',
+                    NumberOfUnits: [5, 0, 0, 0, 0, 0, 0]
+                }]
+            });
+            timesheet.save()
+                .then(function(ret) {
+                    res.render('createtimesheet', { timesheets: ret.entities })
+                })
+                .catch(function(err) {
+                    res.render('createtimesheet', { err: err })
                 })
 
         })

--- a/sample_app/index.js
+++ b/sample_app/index.js
@@ -7,6 +7,7 @@ var express = require('express'),
     metaConfig = require('./config/config.json');
 
 var xeroClient;
+var eventReceiver;
 
 function getXeroClient(session) {
 
@@ -26,10 +27,14 @@ function getXeroClient(session) {
         switch (APPTYPE) {
             case "PUBLIC":
                 xeroClient = new xero.PublicApplication(config);
-                return xeroClient;
                 break;
             case "PARTNER":
                 xeroClient = new xero.PartnerApplication(config);
+                eventReceiver = xeroClient.eventEmitter;
+                eventReceiver.on('xeroTokenUpdate', function(data) {
+                    //Store the data that was received from the xeroTokenRefresh event
+                    console.log("Received xero token refresh: ", data);
+                });
                 break;
             default:
                 throw "No App Type Set!!"

--- a/test/accountingtests.js
+++ b/test/accountingtests.js
@@ -80,27 +80,6 @@ describe('get access for public or partner application', function() {
             done();
         });
 
-<<<<<<< HEAD
-        it('user gets a token and builds the url', function(done) {
-
-            currentApp.getRequestToken(function(err, token, secret) {
-                    if (!err) {
-                        authoriseUrl = currentApp.buildAuthorizeUrl(token);
-                        requestToken = token;
-                        requestSecret = secret;
-                        console.log("URL: " + authoriseUrl);
-                        console.log("token: " + requestToken);
-                        console.log("secret: " + requestSecret);
-                    } else {
-                        throw err;
-                    }
-                })
-                .then(function() {
-                    done();
-                }).catch(function(err) {
-                    done(wrapError(err));
-                });
-=======
         it('user gets a token and builds the url', function() {
             return currentApp.getRequestToken()
                 .then(function(res) {
@@ -110,8 +89,7 @@ describe('get access for public or partner application', function() {
                     console.log("URL: " + authoriseUrl);
                     console.log("token: " + requestToken);
                     console.log("secret: " + requestSecret);
-            });
->>>>>>> a73f23b4dbadd275af13f98669ae2aca66cac448
+                });
         });
 
         describe('gets the request token from the url', function() {

--- a/test/accountingtests.js
+++ b/test/accountingtests.js
@@ -85,7 +85,7 @@ describe('get access for public or partner application', function() {
                 runScripts: false
             });
 
-            browser.debug();
+            //browser.debug();
 
             before(function(done) {
                 if (APPTYPE === "PRIVATE") {

--- a/test/accountingtests.js
+++ b/test/accountingtests.js
@@ -154,11 +154,43 @@ describe('get access for public or partner application', function() {
             });
         });
 
+        describe('swaps the request token for an access token', function() {
+            it('calls the access token method and sets the options', function(done) {
+                currentApp.setAccessToken(requestToken, requestSecret, verifier)
+                    .then(function() {
+                        expect(currentApp.options.accessToken).to.not.equal(undefined);
+                        expect(currentApp.options.accessToken).to.not.equal("");
+                        expect(currentApp.options.accessSecret).to.not.equal(undefined);
+                        expect(currentApp.options.accessSecret).to.not.equal("");
+                        expect(currentApp.options.sessionHandle).to.not.equal(undefined);
+                        expect(currentApp.options.sessionHandle).to.not.equal("");
+                        done();
+                    }).catch(function(err) {
+                        done(wrapError(err));
+                    });
+            });
+
+            it('refreshes the token', function(done) {
+                currentApp.refreshAccessToken()
+                    .then(function() {
+                        expect(currentApp.options.accessToken).to.not.equal(undefined);
+                        expect(currentApp.options.accessToken).to.not.equal("");
+                        expect(currentApp.options.accessSecret).to.not.equal(undefined);
+                        expect(currentApp.options.accessSecret).to.not.equal("");
+                        expect(currentApp.options.sessionHandle).to.not.equal(undefined);
+                        expect(currentApp.options.sessionHandle).to.not.equal("");
+                        done();
+                    }).catch(function(err) {
+                        done(wrapError(err));
+                    });
+            });
+        });
+
 
     });
 });
 
-describe.skip('regression tests', function() {
+describe('regression tests', function() {
 
     var InvoiceID = "";
     var PaymentID = "";

--- a/test/accountingtests.js
+++ b/test/accountingtests.js
@@ -1,6 +1,7 @@
 var chai = require('chai'),
     should = chai.should(),
     expect = chai.expect,
+    sinon = require('sinon'),
     _ = require('lodash'),
     xero = require('..'),
     util = require('util'),
@@ -14,6 +15,7 @@ process.on('uncaughtException', function(err) {
 })
 
 var currentApp;
+var eventReceiver;
 var organisationCountry = '';
 
 var APPTYPE = metaConfig.APPTYPE;
@@ -36,6 +38,8 @@ before('init instance and set options', function(done) {
             throw "No App Type Set!!"
     }
 
+    eventReceiver = currentApp.eventEmitter;
+
     done();
 })
 
@@ -47,7 +51,6 @@ describe('get access for public or partner application', function() {
     });
 
     describe('Get tokens', function() {
-
         var authoriseUrl = "";
         var requestToken = "";
         var requestSecret = "";
@@ -56,8 +59,29 @@ describe('get access for public or partner application', function() {
         var accessToken = "";
         var accessSecret = "";
 
+        //This function is used by the event emitter to receive the event when the token
+        //is automatically refreshed.  We use the 'spy' function so that we can include 
+        //some checks within the tests.
+        var spy = sinon.spy(function() {
+            console.log("Event Received. Creating new Partner App");
+
+            //Create a new application object when we receive new tokens
+            currentApp = new xero.PartnerApplication(config);
+            currentApp.setOptions(arguments[0]);
+            //Reset the event receiver so the listener stack is shared correctly.
+            eventReceiver = currentApp.eventEmitter;
+            eventReceiver.on('xeroTokenUpdate', function(data) { console.log("Event Received: ", data); });
+
+            console.log("Partner app recreated");
+        });
+
+        it('adds the event listener', function(done) {
+            eventReceiver.on('xeroTokenUpdate', spy);
+            done();
+        });
 
         it('user gets a token and builds the url', function(done) {
+
             currentApp.getRequestToken(function(err, token, secret) {
                     if (!err) {
                         authoriseUrl = currentApp.buildAuthorizeUrl(token);
@@ -162,8 +186,12 @@ describe('get access for public or partner application', function() {
                         expect(currentApp.options.accessToken).to.not.equal("");
                         expect(currentApp.options.accessSecret).to.not.equal(undefined);
                         expect(currentApp.options.accessSecret).to.not.equal("");
-                        expect(currentApp.options.sessionHandle).to.not.equal(undefined);
-                        expect(currentApp.options.sessionHandle).to.not.equal("");
+
+                        if (APPTYPE === "PARTNER") {
+                            expect(currentApp.options.sessionHandle).to.not.equal(undefined);
+                            expect(currentApp.options.sessionHandle).to.not.equal("");
+                        }
+
                         done();
                     }).catch(function(err) {
                         done(wrapError(err));
@@ -171,6 +199,11 @@ describe('get access for public or partner application', function() {
             });
 
             it('refreshes the token', function(done) {
+                if (APPTYPE !== "PARTNER") {
+                    this.skip();
+                }
+
+                //Only supported for Partner integrations
                 currentApp.refreshAccessToken()
                     .then(function() {
                         expect(currentApp.options.accessToken).to.not.equal(undefined);
@@ -179,19 +212,18 @@ describe('get access for public or partner application', function() {
                         expect(currentApp.options.accessSecret).to.not.equal("");
                         expect(currentApp.options.sessionHandle).to.not.equal(undefined);
                         expect(currentApp.options.sessionHandle).to.not.equal("");
+
+                        expect(spy.called).to.equal(true);
                         done();
                     }).catch(function(err) {
                         done(wrapError(err));
                     });
             });
         });
-
-
     });
 });
 
 describe('regression tests', function() {
-
     var InvoiceID = "";
     var PaymentID = "";
 
@@ -591,7 +623,37 @@ describe('regression tests', function() {
                 .catch(function(err) {
                     done(wrapError(err));
                 })
-        })
+        });
+
+        it('saves multiple invoices', function(done) {
+            var invoices = [];
+
+            for (var i = 0; i < 10; i++) {
+                invoices.push(currentApp.core.invoices.newInvoice({
+                    Type: 'ACCREC',
+                    Contact: {
+                        Name: 'Department of Testing'
+                    },
+                    DueDate: new Date().toISOString().split("T")[0],
+                    LineItems: [{
+                        Description: 'Services',
+                        Quantity: 2,
+                        UnitAmount: 230,
+                        AccountCode: '400'
+                    }]
+                }));
+            }
+
+            currentApp.core.invoices.saveInvoices(invoices)
+                .then(function(response) {
+                    expect(response.entities).to.have.length.greaterThan(9);
+                    done();
+                })
+                .catch(function(err) {
+                    done(wrapError(err));
+                })
+
+        });
     });
 
     describe('payments', function() {
@@ -1449,6 +1511,4 @@ function wrapError(err) {
         }
         return new Error(err.statusCode + ': ' + msg);
     }
-
-
 }

--- a/test/accountingtests.js
+++ b/test/accountingtests.js
@@ -154,27 +154,11 @@ describe('get access for public or partner application', function() {
             });
         });
 
-        describe('swaps the request token for an access token', function() {
-            it('calls the access token method and sets the options', function(done) {
-                currentApp.getAccessToken(requestToken, requestSecret, verifier, function(err, accessToken, accessSecret, results) {
 
-                        if (!err) {
-                            currentApp.setOptions({ accessToken: accessToken, accessSecret: accessSecret });
-                        } else {
-                            throw err;
-                        }
-                    })
-                    .then(function() {
-                        done();
-                    }).catch(function(err) {
-                        done(wrapError(err));
-                    });
-            });
-        });
     });
 });
 
-describe('regression tests', function() {
+describe.skip('regression tests', function() {
 
     var InvoiceID = "";
     var PaymentID = "";
@@ -1426,6 +1410,13 @@ describe('regression tests', function() {
 function wrapError(err) {
     if (err instanceof Error)
         return err;
-    else if (err.statusCode)
-        return new Error(err.statusCode + ': ' + err.exception.Message);
+    else if (err.statusCode) {
+        var msg = err.data;
+        if (err.exception && err.exception.Message) {
+            msg = err.exception.Message;
+        }
+        return new Error(err.statusCode + ': ' + msg);
+    }
+
+
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -662,6 +662,10 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
+events@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+
 eventsource@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-0.1.6.tgz#0acede849ed7dd1ccc32c811bb11b944d4f29232"
@@ -786,6 +790,12 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
+
+formatio@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
+  dependencies:
+    samsam "~1.1"
 
 fresh@0.2.0:
   version "0.2.0"
@@ -968,6 +978,10 @@ inflight@^1.0.4:
 inherits@2, inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+
+inherits@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
 
 invariant@^2.2.0:
   version "2.2.2"
@@ -1291,6 +1305,10 @@ log4js@~0.6.9:
   dependencies:
     readable-stream "~1.0.2"
     semver "~4.3.3"
+
+lolex@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -1871,6 +1889,10 @@ rimraf@^2.3.3, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.4:
   dependencies:
     glob "^7.0.5"
 
+samsam@1.1.2, samsam@~1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
+
 sax@>=0.6.0, sax@^1.1.4:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
@@ -1903,6 +1925,15 @@ signal-exit@^2.0.0:
 signal-exit@^3.0.0, signal-exit@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+sinon@^1.17.7:
+  version "1.17.7"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-1.17.7.tgz#4542a4f49ba0c45c05eb2e9dd9d203e2b8efe0bf"
+  dependencies:
+    formatio "1.1.1"
+    lolex "1.3.2"
+    samsam "1.1.2"
+    util ">=0.10.3 <1"
 
 slide@^1.1.5:
   version "1.1.6"
@@ -2162,6 +2193,12 @@ url-parse@1.0.x:
   dependencies:
     querystringify "0.0.x"
     requires-port "1.0.x"
+
+"util@>=0.10.3 <1":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
+  dependencies:
+    inherits "2.0.1"
 
 uuid@^3.0.0, uuid@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Added checks in each of the Get/Delete/PutorPost methods to check the expiry prior to executing the request.

If the token is expired, then it will automatically attempt a refresh and set the new token in the current client.

If the refresh fails, then it will reject the promise and fail the call back to the consumer. 

Ready for review!