### PR TITLE
Drop events dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "license": "MIT",
   "dependencies": {
     "dateformat": "~1.0.7-1.2.3",
-    "events": "^1.1.1",
     "lodash": "~2.4.1",
     "log4js": "~0.6.9",
     "lru-cache": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -662,10 +662,6 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
-events@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
-
 eventsource@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-0.1.6.tgz#0acede849ed7dd1ccc32c811bb11b944d4f29232"


### PR DESCRIPTION
The events module is part of the nodeJS standard library. The events package on npm is a polyfill for browsers, etc. No need to use it in this environment, so better to keep the dependency graph small and use the native implementation.