### PR TITLE
Add credit note support

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -348,12 +348,6 @@ Object.assign(Application.prototype, {
             };
         });
     },
-    asArray: function(obj) {
-        if (_.isArray(obj))
-            return obj;
-        else if (!_.isUndefined(obj))
-            return [obj];
-    },
     makeObjectFromPath: function(path) {
         var pathParts = path.split('.');
         var obj = currentObj = {};

--- a/lib/core.js
+++ b/lib/core.js
@@ -15,6 +15,7 @@ var HELPERS = {
     invoices: { file: 'invoices' },
     invoices: { file: 'invoices' },
     invoiceReminders: { file: 'invoicereminders' },
+    creditNotes: { file: 'creditnotes' },
     users: { file: 'users' },
     payments: { file: 'payments' },
     taxRates: { file: 'taxrates' },

--- a/lib/core.js
+++ b/lib/core.js
@@ -13,7 +13,7 @@ var HELPERS = {
     attachments: { file: 'attachments' },
     accounts: { file: 'accounts' },
     invoices: { file: 'invoices' },
-    invoices: { file: 'invoices' },
+    trackingCategories: { file: 'trackingcategories' },
     invoiceReminders: { file: 'invoicereminders' },
     creditNotes: { file: 'creditnotes' },
     users: { file: 'users' },

--- a/lib/entities/accounting/banktransaction.js
+++ b/lib/entities/accounting/banktransaction.js
@@ -50,10 +50,7 @@ var BankTransaction = Entity.extend(BankTransactionSchema, {
         var self = this;
         Object.assign(self, _.omit(obj, 'LineItems', 'Contact'));
         if (obj.LineItems) {
-            var lineItems = this.application.asArray(obj.LineItems.LineItem);
-            _.each(lineItems, function(lineItem) {
-                self.LineItems.push(lineItem);
-            })
+            this.extractArray(obj.LineItems.LineItem, this.LineItems);
         }
         if (obj.Contact)
             Object.assign(self.Contact, new Contact(self.application).fromXmlObj(obj.Contact))

--- a/lib/entities/accounting/creditnote.js
+++ b/lib/entities/accounting/creditnote.js
@@ -28,8 +28,8 @@ var CreditNoteSchema = new Entity.SchemaObject({
         type: CreditNoteContactSchema,
         toObject: 'hasValue'
     },
-    Date: { type: Date },
-    Status: { type: String },
+    Date: { type: String, toObject: 'always' },
+    Status: { type: String, toObject: 'hasValue' },
     LineAmountTypes: { type: String },
     SubTotal: { type: Number },
     TotalTax: { type: Number },
@@ -37,7 +37,7 @@ var CreditNoteSchema = new Entity.SchemaObject({
     UpdatedDateUTC: { type: String },
     CurrencyCode: { type: String },
     FullyPaidOnDate: { type: String },
-    Type: { type: String },
+    Type: { type: String, toObject: 'always' },
     CreditNoteID: { type: String },
     CreditNoteNumber: { type: String },
     CurrencyRate: { type: Number },
@@ -66,6 +66,59 @@ var CreditNote = Entity.extend(CreditNoteSchema, {
         }
 
         return this;
+    },
+    toXml: function() {
+        var creditNote = _.omit(this.toObject(), 'LineItems');
+
+        Object.assign(creditNote, { LineItems: { LineItem: [] } });
+        _.forEach(this.LineItems, function(lineItem) {
+            creditNote.LineItems.LineItem.push(lineItem.toObject());
+        });
+
+        return this.application.js2xml(creditNote, 'CreditNote');
+    },
+    save: function(options) {
+        var self = this;
+        var xml = '<CreditNotes>' + this.toXml() + '</CreditNotes>';
+        var path, method;
+
+        options = options || {};
+
+        if (this.CreditNoteID) {
+            path = 'CreditNotes/' + this.CreditNoteID;
+            method = 'post'
+        } else {
+            path = 'CreditNotes';
+            method = 'put'
+        }
+
+        //Adding other options for saving purposes
+        options.entityPath = 'CreditNotes.CreditNote';
+        options.entityConstructor = function(data) {
+            return self.application.core.creditNotes.newCreditNote(data)
+        };
+
+        return this.application.putOrPostEntity(method, path, xml, options);
+    },
+    saveAllocations: function(allocations) {
+        var self = this;
+        var xml = '<Allocations>';
+
+        _.each(allocations, function(allocation) {
+            xml += "<Allocation>";
+            xml += "<AppliedAmount>" + allocation.AppliedAmount + "</AppliedAmount>";
+            xml += "<Invoice>";
+            xml += "<InvoiceID>" + allocation.InvoiceID + "</InvoiceID>";
+            xml += "</Invoice>";
+            xml += "</Allocation>";
+        });
+
+        xml += "</Allocations>";
+
+        var path, method;
+        path = 'CreditNotes/' + this.CreditNoteID + "/Allocations";
+        method = 'put'
+        return this.application.putOrPostEntity(method, path, xml, {});
     },
 });
 

--- a/lib/entities/accounting/creditnote.js
+++ b/lib/entities/accounting/creditnote.js
@@ -1,0 +1,73 @@
+var _ = require('lodash'),
+    Entity = require('../entity'),
+    logger = require('../../logger'),
+    LineItemSchema = require('../shared').LineItemSchema;
+
+var CreditNoteContactSchema = new Entity.SchemaObject({
+    ContactID: { type: String },
+    Name: { type: String }
+});
+
+var CreditNoteInvoiceType = new Entity.SchemaObject({
+    InvoiceID: { type: String },
+    InvoiceNumber: { type: String }
+});
+
+var CreditNoteAllocationsSchema = new Entity.SchemaObject({
+    AppliedAmount: { type: Number },
+    Date: { type: String },
+    Invoice: {
+        type: CreditNoteInvoiceType,
+        toObject: 'hasValue'
+    },
+});
+
+var CreditNoteSchema = new Entity.SchemaObject({
+    CreditNoteID: { type: String },
+    Contact: {
+        type: CreditNoteContactSchema,
+        toObject: 'hasValue'
+    },
+    Date: { type: Date },
+    Status: { type: String },
+    LineAmountTypes: { type: String },
+    SubTotal: { type: Number },
+    TotalTax: { type: Number },
+    Total: { type: Number },
+    UpdatedDateUTC: { type: String },
+    CurrencyCode: { type: String },
+    FullyPaidOnDate: { type: String },
+    Type: { type: String },
+    CreditNoteID: { type: String },
+    CreditNoteNumber: { type: String },
+    CurrencyRate: { type: Number },
+    RemainingCredit: { type: Number },
+    Allocations: { type: Array, arrayType: CreditNoteAllocationsSchema },
+    LineItems: { type: Array, arrayType: LineItemSchema, toObject: 'hasValue' }
+});
+
+var CreditNote = Entity.extend(CreditNoteSchema, {
+    constructor: function(application, data, options) {
+        logger.debug('CreditNote::constructor');
+        this.Entity.apply(this, arguments);
+    },
+    initialize: function(data, options) {},
+    changes: function(options) {
+        return this._super(options);
+    },
+    _toObject: function(options) {
+        return this._super(options);
+    },
+    fromXmlObj: function(obj) {
+        var self = this;
+        Object.assign(self, _.omit(obj, 'LineItems'));
+        if (obj.LineItems) {
+            this.extractArray(obj.LineItems.LineItem, this.LineItems);
+        }
+
+        return this;
+    },
+});
+
+
+module.exports = CreditNote;

--- a/lib/entities/accounting/invoice.js
+++ b/lib/entities/accounting/invoice.js
@@ -3,30 +3,8 @@ var _ = require('lodash'),
     logger = require('../../logger'),
     ContactSchema = require('./contact').ContactSchema,
     Contact = require('./contact'),
-    PaymentSchema = require('../shared').PaymentSchema
-
-var TrackingCategoryOptionsSchema = new Entity.SchemaObject({
-    TrackingCategoryID: { type: String, toObject: 'hasValue' },
-    Name: { type: String, toObject: 'hasValue' },
-    Option: { type: String, toObject: 'hasValue' }
-});
-
-var TrackingCategorySchema = new Entity.SchemaObject({
-    TrackingCategory: { type: TrackingCategoryOptionsSchema, toObject: 'hasValue' }
-});
-
-var LineItemSchema = new Entity.SchemaObject({
-    Description: { type: String },
-    Quantity: { type: Number },
-    UnitAmount: { type: Number },
-    ItemCode: { type: String },
-    AccountCode: { type: String },
-    TaxType: { type: String },
-    TaxAmount: { type: Number },
-    LineAmount: { type: Number },
-    Tracking: { type: Array, arrayType: TrackingCategorySchema, toObject: 'hasValue' },
-    DiscountRate: { type: Number }
-});
+    PaymentSchema = require('../shared').PaymentSchema,
+    LineItemSchema = require('../shared').LineItemSchema;
 
 var InvoiceSchema = new Entity.SchemaObject({
     Type: { type: String, toObject: 'hasValue' },
@@ -132,3 +110,4 @@ var Invoice = Entity.extend(InvoiceSchema, {
 
 module.exports = Invoice;
 module.exports.InvoiceSchema = InvoiceSchema;
+module.exports.LineItemSchema = LineItemSchema;

--- a/lib/entities/accounting/journal.js
+++ b/lib/entities/accounting/journal.js
@@ -50,10 +50,7 @@ var Journal = Entity.extend(JournalSchema, {
         var self = this;
         Object.assign(self, _.omit(obj, 'JournalLines'));
         if (obj.JournalLines) {
-            var journalLines = this.application.asArray(obj.JournalLines.JournalLine);
-            _.each(journalLines, function(journalLine) {
-                self.JournalLines.push(journalLine);
-            })
+            this.extractArray(obj.JournalLines.JournalLine, this.JournalLines);
         }
 
         return this;

--- a/lib/entities/accounting/report.js
+++ b/lib/entities/accounting/report.js
@@ -43,10 +43,7 @@ var Report = Entity.extend(ReportSchema, {
         Object.assign(self, _.omit(obj, 'Rows', 'Cells', 'ReportTitles'));
 
         if (obj.ReportTitles) {
-            var reportTitles = this.application.asArray(obj.ReportTitles.ReportTitle);
-            _.each(reportTitles, function(reportTitle) {
-                self.ReportTitles.push(reportTitle);
-            })
+            this.extractArray(obj.ReportTitles.ReportTitle, this.ReportTitles);
         }
 
         if (hasMoreRows(obj)) {

--- a/lib/entities/accounting/trackingcategory.js
+++ b/lib/entities/accounting/trackingcategory.js
@@ -26,9 +26,7 @@ var TrackingCategory = Entity.extend(TrackingCategorySchema, {
         var self = this;
         Object.assign(self, _.omit(obj, 'Options'));
         if (obj.Options) {
-            _.each(this.application.asArray(obj.Options.Option), function(option) {
-                self.Options.push(option);
-            })
+            this.extractArray(obj.Options.Option, this.Options);
         }
 
         return this;

--- a/lib/entities/accounting/trackingoption.js
+++ b/lib/entities/accounting/trackingoption.js
@@ -1,53 +1,23 @@
 var _ = require('lodash'),
     Entity = require('../entity'),
     logger = require('../../logger'),
-    dateformat = require('dateformat'),
-    fs = require('fs')
+    TrackingOptionSchema = require('../shared').TrackingOptionSchema;
 
-var AttachmentSchema = new Entity.SchemaObject({
-    AttachmentID: { type: String, toObject: 'never' },
-    FileName: { type: String, toObject: 'always' },
-    Url: { type: String, toObject: 'always' },
-    MimeType: { type: String, toObject: 'always' },
-    ContentLength: { type: Number, toObject: 'always' }
-});
-
-
-var Attachment = Entity.extend(AttachmentSchema, {
+var TrackingOption = Entity.extend(TrackingOptionSchema, {
     constructor: function(application, data, options) {
-        logger.debug('Attachment::constructor');
+        logger.debug('TrackingOption::constructor');
         this.Entity.apply(this, arguments);
     },
     initialize: function(data, options) {},
-    getContent: function(ownerPath) {
-        return this.application.core.attachments.getContent(ownerPath, this.FileName);
+    changes: function(options) {
+        return this._super(options);
     },
-    save: function(ownerPath, streamOrFilePath) {
-        var self = this;
-        var path = ownerPath + '/Attachments/' + this.FileName;
-
-        var base64string = base64_encode(streamOrFilePath);
-        console.log(base64string);
-        console.log(path);
-
-        return this.application.postEntity(path, base64string, { type: this.MimeType })
-            .then(function(ret) {
-                console.log(ret);
-                return ret.response.Attachments.Attachment;
-            })
-            .catch(function(err) {
-                console.log(err);
-            })
-
-        function base64_encode(file) {
-            // read binary data
-            var bitmap = fs.readFileSync(file);
-            // convert binary data to base64 encoded string
-            return new Buffer(bitmap).toString('base64');
-        }
+    _toObject: function(options) {
+        return this._super(options);
+    },
+    delete: function() {
+        return this.deleteEntities({ id: this.TrackingOptionID });
     }
 });
 
-
-module.exports = Attachment;
-module.exports.AttachmentSchema = AttachmentSchema;
+module.exports = TrackingOption;

--- a/lib/entities/entity.js
+++ b/lib/entities/entity.js
@@ -37,12 +37,18 @@ module.exports.extend = function(schema, classProps, staticProps) {
             return Object.assign(this, obj);
         },
         extractArray: function(src, dest) {
-            var items = this.application.asArray(src);
+            var items = this.asArray(src);
             _.each(items, function(item) {
                 dest.push(item);
             })
 
-        }
+        },
+        asArray: function(obj) {
+            if (_.isArray(obj))
+                return obj;
+            else if (!_.isUndefined(obj))
+                return [obj];
+        },
     })
 
     return Entity.extend(Object.assign(classProps, { Entity: Entity }), staticProps);

--- a/lib/entities/payroll/timesheet.js
+++ b/lib/entities/payroll/timesheet.js
@@ -34,6 +34,11 @@ var Timesheet = Entity.extend(TimesheetSchema, {
     fromXmlObj: function(obj) {
         var self = this;
         Object.assign(self, _.omit(obj, 'TimesheetLines'));
+        /**
+         * Code commented as the 'asArray' function has been removed.
+         */
+
+        /* 
         if (obj.TimesheetLines) {
             var items = this.application.asArray(obj.TimesheetLines.TimesheetLine);
             _.each(items, function(item) {
@@ -46,6 +51,7 @@ var Timesheet = Entity.extend(TimesheetSchema, {
 
             })
         }
+        */
 
         return this;
     },

--- a/lib/entities/shared.js
+++ b/lib/entities/shared.js
@@ -88,3 +88,26 @@ module.exports.TrackingOptionSchema = new Entity.SchemaObject({
     Name: { type: String, toObject: 'always' },
     Status: { type: String, toObject: 'always' }
 });
+
+var TrackingCategoryOptionsSchema = new Entity.SchemaObject({
+    TrackingCategoryID: { type: String, toObject: 'hasValue' },
+    Name: { type: String, toObject: 'hasValue' },
+    Option: { type: String, toObject: 'hasValue' }
+});
+
+var TrackingCategorySchema = new Entity.SchemaObject({
+    TrackingCategory: { type: TrackingCategoryOptionsSchema, toObject: 'hasValue' }
+});
+
+module.exports.LineItemSchema = new Entity.SchemaObject({
+    Description: { type: String },
+    Quantity: { type: Number },
+    UnitAmount: { type: Number },
+    ItemCode: { type: String },
+    AccountCode: { type: String },
+    TaxType: { type: String },
+    TaxAmount: { type: Number },
+    LineAmount: { type: Number },
+    Tracking: { type: Array, arrayType: TrackingCategorySchema, toObject: 'hasValue' },
+    DiscountRate: { type: Number }
+});

--- a/lib/entity_helpers/accounting/creditnotes.js
+++ b/lib/entity_helpers/accounting/creditnotes.js
@@ -8,10 +8,13 @@ var CreditNotes = EntityHelper.extend({
     constructor: function(application, options) {
         EntityHelper.call(this, application, Object.assign({ entityName: 'CreditNote', entityPlural: 'CreditNotes' }, options));
     },
+    newCreditNote: function(data, options) {
+        return new CreditNote(this.application, data, options);
+    },
     getCreditNotes: function(options, callback) {
         var self = this;
         var clonedOptions = _.clone(options || {});
-        clonedOptions.entityConstructor = function(data) { return new CreditNote(data) };
+        clonedOptions.entityConstructor = function(data) { return self.newCreditNote(data) };
         return this.getEntities(clonedOptions)
     },
     getCreditNote: function(id) {

--- a/lib/entity_helpers/accounting/creditnotes.js
+++ b/lib/entity_helpers/accounting/creditnotes.js
@@ -1,0 +1,25 @@
+var _ = require('lodash'),
+    logger = require('../../logger'),
+    EntityHelper = require('../entity_helper'),
+    CreditNote = require('../../entities/accounting/creditnote'),
+    util = require('util')
+
+var CreditNotes = EntityHelper.extend({
+    constructor: function(application, options) {
+        EntityHelper.call(this, application, Object.assign({ entityName: 'CreditNote', entityPlural: 'CreditNotes' }, options));
+    },
+    getCreditNotes: function(options, callback) {
+        var self = this;
+        var clonedOptions = _.clone(options || {});
+        clonedOptions.entityConstructor = function(data) { return new CreditNote(data) };
+        return this.getEntities(clonedOptions)
+    },
+    getCreditNote: function(id) {
+        return this.getCreditNotes({ id: id })
+            .then(function(creditNotes) {
+                return _.first(creditNotes);
+            })
+    },
+})
+
+module.exports = CreditNotes;

--- a/test/accountingtests.js
+++ b/test/accountingtests.js
@@ -17,6 +17,11 @@ process.on('uncaughtException', function(err) {
 var currentApp;
 var eventReceiver;
 var organisationCountry = '';
+var expenseAccount = '';
+var revenueAccount = '';
+var salesAccount = '';
+
+var someContactId = "";
 
 var APPTYPE = metaConfig.APPTYPE;
 var config = metaConfig[APPTYPE.toLowerCase()];
@@ -412,7 +417,6 @@ describe('regression tests', function() {
 
         it('Generates an Aged Receivables Report', function(done) {
 
-            var someContactId = "";
             currentApp.core.contacts.getContacts()
                 .then(function(contacts) {
                     someContactId = _.first(contacts).ContactID;
@@ -444,7 +448,6 @@ describe('regression tests', function() {
 
         it('Generates an Aged Payables Report', function(done) {
 
-            var someContactId = "";
             currentApp.core.contacts.getContacts()
                 .then(function(contacts) {
                     someContactId = _.first(contacts).ContactID;
@@ -470,6 +473,10 @@ describe('regression tests', function() {
                     done(wrapError(err));
                 })
         });
+
+        function getContactID() {
+
+        }
 
         function validateRows(rows) {
             expect(rows).to.have.length.greaterThan(0);
@@ -522,416 +529,6 @@ describe('regression tests', function() {
         })
     });
 
-    describe('Credit Notes', function() {
-        var creditNoteID = "";
-        it('get', function(done) {
-            currentApp.core.creditNotes.getCreditNotes()
-                .then(function(creditNotes) {
-                    expect(creditNotes).to.have.length.greaterThan(0);
-                    creditNotes.forEach(function(creditNote) {
-                        //Check the contact
-                        if (creditNote.Contact) {
-                            expect(creditNote.Contact.ContactID).to.not.equal("");
-                            expect(creditNote.Contact.ContactID).to.not.equal(undefined);
-                            expect(creditNote.Contact.Name).to.not.equal("");
-                            expect(creditNote.Contact.Name).to.not.equal(undefined);
-                        } else {
-                            console.log("Credit note has no contact record");
-                        }
-
-                        expect(creditNote.Date).to.not.equal("");
-                        expect(creditNote.Date).to.not.equal(undefined);
-
-                        expect(creditNote.Status).to.be.oneOf(["DRAFT", "SUBMITTED", "DELETED", "AUTHORISED", "PAID", "VOIDED"]);
-                        expect(creditNote.LineAmountTypes).to.be.oneOf(["Exclusive", "Inclusive", "NoTax"]);
-
-                        expect(creditNote.SubTotal).to.be.a('Number');
-                        expect(creditNote.SubTotal).to.be.greaterThan(0);
-                        expect(creditNote.TotalTax).to.be.a('Number');
-                        expect(creditNote.TotalTax).to.be.greaterThan(0);
-                        expect(creditNote.Total).to.be.a('Number');
-                        expect(creditNote.Total).to.be.greaterThan(0);
-
-                        expect(creditNote.UpdatedDateUTC).to.not.equal("");
-                        expect(creditNote.UpdatedDateUTC).to.not.equal(undefined);
-
-                        expect(creditNote.CurrencyCode).to.not.equal("");
-                        expect(creditNote.CurrencyCode).to.not.equal(undefined);
-
-                        expect(creditNote.FullyPaidOnDate).to.not.equal("");
-                        expect(creditNote.FullyPaidOnDate).to.not.equal(undefined);
-
-                        expect(creditNote.Type).to.be.oneOf(["ACCPAYCREDIT", "ACCRECCREDIT"]);
-
-                        expect(creditNote.CreditNoteID).to.not.equal("");
-                        expect(creditNote.CreditNoteID).to.not.equal(undefined);
-
-                        //Set the variable for the next test.
-                        creditNoteID = creditNote.CreditNoteID;
-
-                        expect(creditNote.CreditNoteNumber).to.not.equal("");
-                        expect(creditNote.CreditNoteNumber).to.not.equal(undefined);
-
-                        expect(creditNote.CurrencyRate).to.be.a('Number');
-                        expect(creditNote.CurrencyRate).to.be.greaterThan(0);
-
-                        expect(creditNote.RemainingCredit).to.be.a('Number');
-                        expect(creditNote.RemainingCredit).to.be.at.least(0);
-
-                        if (creditNote.Allocations) {
-                            creditNote.Allocations.forEach(function(allocation) {
-                                expect(allocation.AppliedAmount).to.be.a('Number');
-                                expect(allocation.AppliedAmount).to.be.at.least(0);
-
-                                expect(allocation.Date).to.not.equal("");
-                                expect(allocation.Date).to.not.equal(undefined);
-
-                                if (allocation.Invoice) {
-                                    expect(allocation.Invoice.InvoiceID).to.not.equal("");
-                                    expect(allocation.Invoice.InvoiceID).to.not.equal(undefined);
-
-                                    expect(allocation.Invoice.InvoiceNumber).to.not.equal("");
-                                    expect(allocation.Invoice.InvoiceNumber).to.not.equal(undefined);
-                                } else {
-                                    console.log("Credit note allocation has no invoice record");
-                                }
-                            });
-                        } else {
-                            console.log("Credit note has no allocation records");
-                        }
-                    });
-                    done();
-                })
-                .catch(function(err) {
-                    console.log(err);
-                    done(wrapError(err));
-                })
-        });
-
-        it('get a single credit note', function(done) {
-            currentApp.core.creditNotes.getCreditNote(creditNoteID)
-                .then(function(creditNote) {
-                    //Check the contact
-                    if (creditNote.Contact) {
-                        expect(creditNote.Contact.ContactID).to.not.equal("");
-                        expect(creditNote.Contact.ContactID).to.not.equal(undefined);
-                        expect(creditNote.Contact.Name).to.not.equal("");
-                        expect(creditNote.Contact.Name).to.not.equal(undefined);
-                    } else {
-                        console.log("Credit note has no contact record");
-                    }
-
-                    expect(creditNote.Date).to.not.equal("");
-                    expect(creditNote.Date).to.not.equal(undefined);
-
-                    expect(creditNote.Status).to.be.oneOf(["DRAFT", "SUBMITTED", "DELETED", "AUTHORISED", "PAID", "VOIDED"]);
-                    expect(creditNote.LineAmountTypes).to.be.oneOf(["Exclusive", "Inclusive", "NoTax"]);
-
-                    expect(creditNote.SubTotal).to.be.a('Number');
-                    expect(creditNote.SubTotal).to.be.greaterThan(0);
-                    expect(creditNote.TotalTax).to.be.a('Number');
-                    expect(creditNote.TotalTax).to.be.greaterThan(0);
-                    expect(creditNote.Total).to.be.a('Number');
-                    expect(creditNote.Total).to.be.greaterThan(0);
-
-                    expect(creditNote.UpdatedDateUTC).to.not.equal("");
-                    expect(creditNote.UpdatedDateUTC).to.not.equal(undefined);
-
-                    expect(creditNote.CurrencyCode).to.not.equal("");
-                    expect(creditNote.CurrencyCode).to.not.equal(undefined);
-
-                    expect(creditNote.FullyPaidOnDate).to.not.equal("");
-                    expect(creditNote.FullyPaidOnDate).to.not.equal(undefined);
-
-                    expect(creditNote.Type).to.be.oneOf(["ACCPAYCREDIT", "ACCRECCREDIT"]);
-
-                    expect(creditNote.CreditNoteID).to.not.equal("");
-                    expect(creditNote.CreditNoteID).to.not.equal(undefined);
-
-                    //Set the variable for the next test.
-                    creditNoteID = creditNote.CreditNoteID;
-
-                    expect(creditNote.CreditNoteNumber).to.not.equal("");
-                    expect(creditNote.CreditNoteNumber).to.not.equal(undefined);
-
-                    expect(creditNote.CurrencyRate).to.be.a('Number');
-                    expect(creditNote.CurrencyRate).to.be.greaterThan(0);
-
-                    expect(creditNote.RemainingCredit).to.be.a('Number');
-                    expect(creditNote.RemainingCredit).to.be.at.least(0);
-
-                    if (creditNote.Allocations) {
-                        creditNote.Allocations.forEach(function(allocation) {
-                            expect(allocation.AppliedAmount).to.be.a('Number');
-                            expect(allocation.AppliedAmount).to.be.at.least(0);
-
-                            expect(allocation.Date).to.not.equal("");
-                            expect(allocation.Date).to.not.equal(undefined);
-
-                            if (allocation.Invoice) {
-                                expect(allocation.Invoice.InvoiceID).to.not.equal("");
-                                expect(allocation.Invoice.InvoiceID).to.not.equal(undefined);
-
-                                expect(allocation.Invoice.InvoiceNumber).to.not.equal("");
-                                expect(allocation.Invoice.InvoiceNumber).to.not.equal(undefined);
-                            } else {
-                                console.log("Credit note allocation has no invoice record");
-                            }
-                        });
-                    } else {
-                        console.log("Credit note has no allocation records");
-                    }
-
-                    if (creditNote.LineItems) {
-                        creditNote.LineItems.forEach(function(lineItem) {
-
-                            if (lineItem.LineItemID) {
-                                expect(lineItem.LineItemID).to.not.equal("");
-                            }
-
-                            expect(lineItem.Description).to.not.equal("");
-                            expect(lineItem.Description).to.not.equal(undefined);
-
-                            if (lineItem.Quantity) {
-                                expect(lineItem.Quantity).to.be.a('Number');
-                                expect(lineItem.Quantity).to.be.at.least(0);
-
-                                expect(lineItem.UnitAmount).to.be.a('Number');
-                                expect(lineItem.UnitAmount).to.be.at.least(0);
-
-                                expect(lineItem.ItemCode).to.be.a('String');
-                                expect(lineItem.ItemCode).to.not.equal("");
-                                expect(lineItem.ItemCode).to.not.equal(undefined);
-
-                                expect(lineItem.AccountCode).to.be.a('String');
-                                expect(lineItem.AccountCode).to.not.equal("");
-                                expect(lineItem.AccountCode).to.not.equal(undefined);
-
-                                expect(lineItem.TaxType).to.not.equal("");
-                                expect(lineItem.TaxType).to.not.equal(undefined);
-
-                                expect(lineItem.TaxAmount).to.be.a('Number');
-                                expect(lineItem.TaxAmount).to.be.at.least(0);
-
-                                expect(lineItem.LineAmount).to.be.a('Number');
-                                expect(lineItem.LineAmount).to.be.at.least(0);
-
-                                if (lineItem.Tracking) {
-                                    lineItem.Tracking.forEach(function(trackingCategory) {
-                                        expect(trackingCategory.Name).to.not.equal("");
-                                        expect(trackingCategory.Name).to.not.equal(undefined);
-
-                                        expect(trackingCategory.Option).to.not.equal("");
-                                        expect(trackingCategory.Option).to.not.equal(undefined);
-
-                                        expect(trackingCategory.TrackingCategoryID).to.not.equal("");
-                                        expect(trackingCategory.TrackingCategoryID).to.not.equal(undefined);
-
-                                        expect(trackingCategory.TrackingOptionID).to.not.equal("");
-                                        expect(trackingCategory.TrackingOptionID).to.not.equal(undefined);
-                                    });
-                                }
-                            }
-
-
-
-                        });
-                    } else {
-                        console.log("Credit note has no line item records");
-                    }
-                    done();
-                })
-                .catch(function(err) {
-                    console.log(err);
-                    done(wrapError(err));
-                })
-        });
-    });
-
-    describe('currencies', function() {
-
-        it('get', function(done) {
-            currentApp.core.currencies.getCurrencies()
-                .then(function(currencies) {
-                    expect(currencies).to.have.length.greaterThan(0);
-                    currencies.forEach(function(currencies) {
-                        expect(currencies.Code).to.not.equal(undefined);
-                        expect(currencies.Code).to.not.equal("");
-                        expect(currencies.Description).to.not.equal(undefined);
-                        expect(currencies.Description).to.not.equal("");
-                    });
-                    done();
-                })
-                .catch(function(err) {
-                    console.log(err);
-                    done(wrapError(err));
-                })
-        });
-    });
-
-    describe('Invoice Reminders', function() {
-
-        it('get', function(done) {
-            currentApp.core.invoiceReminders.getInvoiceReminders()
-                .then(function(invoiceReminders) {
-                    expect(invoiceReminders).to.have.length.greaterThan(0);
-                    invoiceReminders.forEach(function(invoiceReminder) {
-                        expect(invoiceReminder.Enabled).to.be.oneOf([true, false]);
-                    });
-                    done();
-                })
-                .catch(function(err) {
-                    console.log(err);
-                    done(wrapError(err));
-                })
-        });
-    });
-
-
-
-    describe('branding themes', function() {
-
-        var brandingThemeID = "";
-
-        it('get', function(done) {
-            currentApp.core.brandingThemes.getBrandingThemes()
-                .then(function(brandingThemes) {
-                    expect(brandingThemes).to.have.length.greaterThan(0);
-                    brandingThemes.forEach(function(brandingTheme) {
-                        expect(brandingTheme.BrandingThemeID).to.not.equal(undefined);
-                        expect(brandingTheme.BrandingThemeID).to.not.equal("");
-                        expect(brandingTheme.Name).to.not.equal(undefined);
-                        expect(brandingTheme.Name).to.not.equal("");
-
-                        brandingThemeID = brandingTheme.BrandingThemeID;
-                    });
-                    done();
-                })
-                .catch(function(err) {
-                    console.log(err);
-                    done(wrapError(err));
-                })
-        });
-
-        it('get by ID', function(done) {
-            currentApp.core.brandingThemes.getBrandingTheme(brandingThemeID)
-                .then(function(brandingTheme) {
-
-                    expect(brandingTheme.BrandingThemeID).to.not.equal(undefined);
-                    expect(brandingTheme.BrandingThemeID).to.not.equal("");
-                    expect(brandingTheme.Name).to.not.equal(undefined);
-                    expect(brandingTheme.Name).to.not.equal("");
-
-                    done();
-                })
-                .catch(function(err) {
-                    console.log(err);
-                    done(wrapError(err));
-                })
-        })
-    })
-
-    describe('taxRates', function() {
-
-        var createdTaxRate;
-
-        it('gets tax rates', function(done) {
-            currentApp.core.taxRates.getTaxRates()
-                .then(function(taxRates) {
-                    // This test requires that some tax rates are set up in the targeted company
-                    expect(taxRates).to.have.length.greaterThan(0);
-                    _.each(taxRates, function(taxRate) {
-                        expect(taxRate.Name).to.not.equal("");
-                        expect(taxRate.Name).to.not.equal(undefined);
-                        expect(taxRate.TaxType).to.not.equal("");
-                        expect(taxRate.TaxType).to.not.equal(undefined);
-                        expect(taxRate.CanApplyToAssets).to.be.oneOf([true, false]);
-                        expect(taxRate.CanApplyToEquity).to.be.oneOf([true, false]);
-                        expect(taxRate.CanApplyToExpenses).to.be.oneOf([true, false]);
-                        expect(taxRate.CanApplyToLiabilities).to.be.oneOf([true, false]);
-                        expect(taxRate.CanApplyToRevenue).to.be.oneOf([true, false]);
-                        expect(taxRate.DisplayTaxRate).to.be.a('Number');
-                        expect(taxRate.Status).to.be.oneOf(['ACTIVE', 'DELETED', 'ARCHIVED']);
-                        expect(taxRate.TaxComponents).to.have.length.greaterThan(0);
-
-                        _.each(taxRate.TaxComponents, function(taxComponent) {
-                            expect(taxComponent.Name).to.not.equal("");
-                            expect(taxComponent.Name).to.not.equal(undefined);
-                            expect(taxComponent.Rate).to.be.a('String');
-                            //Hacked to a string as the framework doesn't recursively translate nested objects
-                            expect(taxComponent.IsCompound).to.be.oneOf(["true", "false"]);
-                        });
-                    });
-                    done();
-                })
-                .catch(function(err) {
-                    console.log(err);
-                    done(wrapError(err));
-                })
-        });
-
-        it('creates a new tax rate', function(done) {
-            var taxrate = {
-                Name: '20% GST on Expenses',
-                TaxComponents: [{
-                    Name: 'GST',
-                    Rate: 20.1234,
-                    IsCompound: false
-                }],
-                ReportTaxType: 'INPUT'
-            }
-
-            var taxRate = currentApp.core.taxRates.newTaxRate(taxrate);
-
-            taxRate.save()
-                .then(function(response) {
-                    expect(response.entities).to.have.length.greaterThan(0);
-                    createdTaxRate = response.entities[0];
-
-                    expect(createdTaxRate.Name).to.equal(taxrate.Name);
-                    expect(createdTaxRate.TaxType).to.match(/TAX[0-9]{3}/);
-                    expect(createdTaxRate.CanApplyToAssets).to.be.oneOf([true, false]);
-                    expect(createdTaxRate.CanApplyToEquity).to.be.oneOf([true, false]);
-                    expect(createdTaxRate.CanApplyToExpenses).to.be.oneOf([true, false]);
-                    expect(createdTaxRate.CanApplyToLiabilities).to.be.oneOf([true, false]);
-                    expect(createdTaxRate.CanApplyToRevenue).to.be.oneOf([true, false]);
-                    expect(createdTaxRate.DisplayTaxRate).to.equal(taxrate.TaxComponents[0].Rate);
-                    expect(createdTaxRate.EffectiveRate).to.equal(taxrate.TaxComponents[0].Rate);
-                    expect(createdTaxRate.Status).to.equal('ACTIVE');
-                    expect(createdTaxRate.ReportTaxType).to.equal(taxrate.ReportTaxType);
-
-                    createdTaxRate.TaxComponents.forEach(function(taxComponent) {
-                        expect(taxComponent.Name).to.equal(taxrate.TaxComponents[0].Name);
-
-                        //This is hacked toString() because of: https://github.com/jordanwalsh23/xero-node/issues/13
-                        expect(taxComponent.Rate).to.equal(taxrate.TaxComponents[0].Rate.toString());
-                        expect(taxComponent.IsCompound).to.equal(taxrate.TaxComponents[0].IsCompound.toString());
-                    });
-                    done();
-                })
-                .catch(function(err) {
-                    console.log(err);
-                    done(wrapError(err));
-                })
-        });
-
-        it('updates the taxrate to DELETED', function(done) {
-
-            createdTaxRate.delete()
-                .then(function(response) {
-                    expect(response.entities).to.have.lengthOf(1);
-                    expect(response.entities[0].Status).to.equal("DELETED");
-                    done();
-                })
-                .catch(function(err) {
-                    console.log(err);
-                    done(wrapError(err));
-                })
-
-        });
-
-    });
-
     describe('accounts', function() {
 
         //Accounts supporting data
@@ -968,6 +565,21 @@ describe('regression tests', function() {
                                 expect(account.CurrencyCode).to.be.a('string');
                                 expect(account.CurrencyCode).to.not.equal("");
                             }
+                        }
+
+                        if (account.Type === "EXPENSE" && !account.SystemAccount && !expenseAccount) {
+                            //Save this for later use
+                            expenseAccount = account.Code;
+                        }
+
+                        if (account.Type === "SALES" && !account.SystemAccount && !salesAccount) {
+                            //Save this for later use
+                            salesAccount = account.Code;
+                        }
+
+                        if (account.Type === "REVENUE" && !account.SystemAccount && !revenueAccount) {
+                            //Save this for later use
+                            revenueAccount = account.Code;
                         }
 
                         expect(account.Status).to.be.a('string');
@@ -1126,6 +738,569 @@ describe('regression tests', function() {
 
     });
 
+    describe('Credit Notes', function() {
+        var creditNoteID = "";
+        it('get', function(done) {
+            currentApp.core.creditNotes.getCreditNotes()
+                .then(function(creditNotes) {
+                    expect(creditNotes).to.have.length.greaterThan(0);
+                    creditNotes.forEach(function(creditNote) {
+                        //Check the contact
+                        if (creditNote.Contact) {
+                            expect(creditNote.Contact.ContactID).to.not.equal("");
+                            expect(creditNote.Contact.ContactID).to.not.equal(undefined);
+                            expect(creditNote.Contact.Name).to.not.equal("");
+                            expect(creditNote.Contact.Name).to.not.equal(undefined);
+                        } else {
+                            console.log("Credit note has no contact record");
+                        }
+
+                        expect(creditNote.Date).to.not.equal("");
+                        expect(creditNote.Date).to.not.equal(undefined);
+
+                        expect(creditNote.Status).to.be.oneOf(["DRAFT", "SUBMITTED", "DELETED", "AUTHORISED", "PAID", "VOIDED"]);
+                        expect(creditNote.LineAmountTypes).to.be.oneOf(["Exclusive", "Inclusive", "NoTax"]);
+
+                        expect(creditNote.SubTotal).to.be.a('Number');
+                        expect(creditNote.SubTotal).to.be.at.least(0);
+                        expect(creditNote.TotalTax).to.be.a('Number');
+                        expect(creditNote.TotalTax).to.be.at.least(0);
+                        expect(creditNote.Total).to.be.a('Number');
+                        expect(creditNote.Total).to.be.at.least(0);
+
+                        expect(creditNote.UpdatedDateUTC).to.not.equal("");
+                        expect(creditNote.UpdatedDateUTC).to.not.equal(undefined);
+
+                        expect(creditNote.CurrencyCode).to.not.equal("");
+                        expect(creditNote.CurrencyCode).to.not.equal(undefined);
+
+                        if (creditNote.FullyPaidOnDate) {
+                            expect(creditNote.FullyPaidOnDate).to.not.equal("");
+                        }
+
+                        expect(creditNote.Type).to.be.oneOf(["ACCPAYCREDIT", "ACCRECCREDIT"]);
+
+                        expect(creditNote.CreditNoteID).to.not.equal("");
+                        expect(creditNote.CreditNoteID).to.not.equal(undefined);
+
+                        //Set the variable for the next test.
+                        creditNoteID = creditNote.CreditNoteID;
+
+                        if (creditNote.CreditNoteNumber) {
+                            expect(creditNote.CreditNoteNumber).to.not.equal("");
+                        }
+
+                        expect(creditNote.CurrencyRate).to.be.a('Number');
+                        expect(creditNote.CurrencyRate).to.be.at.least(0);
+
+                        expect(creditNote.RemainingCredit).to.be.a('Number');
+                        expect(creditNote.RemainingCredit).to.be.at.least(0);
+
+                        if (creditNote.Allocations) {
+                            creditNote.Allocations.forEach(function(allocation) {
+                                expect(allocation.AppliedAmount).to.be.a('Number');
+                                expect(allocation.AppliedAmount).to.be.at.least(0);
+
+                                expect(allocation.Date).to.not.equal("");
+                                expect(allocation.Date).to.not.equal(undefined);
+
+                                if (allocation.Invoice) {
+                                    expect(allocation.Invoice.InvoiceID).to.not.equal("");
+                                    expect(allocation.Invoice.InvoiceID).to.not.equal(undefined);
+
+                                    expect(allocation.Invoice.InvoiceNumber).to.not.equal("");
+                                    expect(allocation.Invoice.InvoiceNumber).to.not.equal(undefined);
+                                } else {
+                                    console.log("Credit note allocation has no invoice record");
+                                }
+                            });
+                        } else {
+                            console.log("Credit note has no allocation records");
+                        }
+                    });
+                    done();
+                })
+                .catch(function(err) {
+                    console.log(err);
+                    done(wrapError(err));
+                })
+        });
+
+        it('get a single credit note', function(done) {
+            currentApp.core.creditNotes.getCreditNote(creditNoteID)
+                .then(function(creditNote) {
+                    //Check the contact
+                    if (creditNote.Contact) {
+                        expect(creditNote.Contact.ContactID).to.not.equal("");
+                        expect(creditNote.Contact.ContactID).to.not.equal(undefined);
+                        expect(creditNote.Contact.Name).to.not.equal("");
+                        expect(creditNote.Contact.Name).to.not.equal(undefined);
+                    } else {
+                        console.log("Credit note has no contact record");
+                    }
+
+                    expect(creditNote.Date).to.not.equal("");
+                    expect(creditNote.Date).to.not.equal(undefined);
+
+                    expect(creditNote.Status).to.be.oneOf(["DRAFT", "SUBMITTED", "DELETED", "AUTHORISED", "PAID", "VOIDED"]);
+                    expect(creditNote.LineAmountTypes).to.be.oneOf(["Exclusive", "Inclusive", "NoTax"]);
+
+                    expect(creditNote.SubTotal).to.be.a('Number');
+                    expect(creditNote.SubTotal).to.be.at.least(0);
+                    expect(creditNote.TotalTax).to.be.a('Number');
+                    expect(creditNote.TotalTax).to.be.at.least(0);
+                    expect(creditNote.Total).to.be.a('Number');
+                    expect(creditNote.Total).to.be.at.least(0);
+
+                    expect(creditNote.UpdatedDateUTC).to.not.equal("");
+                    expect(creditNote.UpdatedDateUTC).to.not.equal(undefined);
+
+                    expect(creditNote.CurrencyCode).to.not.equal("");
+                    expect(creditNote.CurrencyCode).to.not.equal(undefined);
+
+                    if (creditNote.FullyPaidOnDate) {
+                        expect(creditNote.FullyPaidOnDate).to.not.equal("");
+                    }
+
+                    expect(creditNote.Type).to.be.oneOf(["ACCPAYCREDIT", "ACCRECCREDIT"]);
+
+                    expect(creditNote.CreditNoteID).to.not.equal("");
+                    expect(creditNote.CreditNoteID).to.not.equal(undefined);
+
+                    //Set the variable for the next test.
+                    creditNoteID = creditNote.CreditNoteID;
+
+                    if (creditNote.CreditNoteNumber) {
+                        expect(creditNote.CreditNoteNumber).to.not.equal("");
+                    }
+
+                    expect(creditNote.CurrencyRate).to.be.a('Number');
+                    expect(creditNote.CurrencyRate).to.be.at.least(0);
+
+                    expect(creditNote.RemainingCredit).to.be.a('Number');
+                    expect(creditNote.RemainingCredit).to.be.at.least(0);
+
+                    if (creditNote.Allocations) {
+                        creditNote.Allocations.forEach(function(allocation) {
+                            expect(allocation.AppliedAmount).to.be.a('Number');
+                            expect(allocation.AppliedAmount).to.be.at.least(0);
+
+                            expect(allocation.Date).to.not.equal("");
+                            expect(allocation.Date).to.not.equal(undefined);
+
+                            if (allocation.Invoice) {
+                                expect(allocation.Invoice.InvoiceID).to.not.equal("");
+                                expect(allocation.Invoice.InvoiceID).to.not.equal(undefined);
+
+                                expect(allocation.Invoice.InvoiceNumber).to.not.equal("");
+                                expect(allocation.Invoice.InvoiceNumber).to.not.equal(undefined);
+                            } else {
+                                console.log("Credit note allocation has no invoice record");
+                            }
+                        });
+                    } else {
+                        console.log("Credit note has no allocation records");
+                    }
+
+                    if (creditNote.LineItems) {
+                        creditNote.LineItems.forEach(function(lineItem) {
+
+                            if (lineItem.LineItemID) {
+                                expect(lineItem.LineItemID).to.not.equal("");
+                            }
+
+                            expect(lineItem.Description).to.not.equal("");
+                            expect(lineItem.Description).to.not.equal(undefined);
+
+                            if (lineItem.Quantity) {
+                                expect(lineItem.Quantity).to.be.a('Number');
+                                expect(lineItem.Quantity).to.be.at.least(0);
+
+                                expect(lineItem.UnitAmount).to.be.a('Number');
+                                expect(lineItem.UnitAmount).to.be.at.least(0);
+
+                                expect(lineItem.ItemCode).to.be.a('String');
+                                expect(lineItem.ItemCode).to.not.equal("");
+                                expect(lineItem.ItemCode).to.not.equal(undefined);
+
+                                expect(lineItem.AccountCode).to.be.a('String');
+                                expect(lineItem.AccountCode).to.not.equal("");
+                                expect(lineItem.AccountCode).to.not.equal(undefined);
+
+                                expect(lineItem.TaxType).to.not.equal("");
+                                expect(lineItem.TaxType).to.not.equal(undefined);
+
+                                expect(lineItem.TaxAmount).to.be.a('Number');
+                                expect(lineItem.TaxAmount).to.be.at.least(0);
+
+                                expect(lineItem.LineAmount).to.be.a('Number');
+                                expect(lineItem.LineAmount).to.be.at.least(0);
+
+                                if (lineItem.Tracking) {
+                                    lineItem.Tracking.forEach(function(trackingCategory) {
+                                        expect(trackingCategory.Name).to.not.equal("");
+                                        expect(trackingCategory.Name).to.not.equal(undefined);
+
+                                        expect(trackingCategory.Option).to.not.equal("");
+                                        expect(trackingCategory.Option).to.not.equal(undefined);
+
+                                        expect(trackingCategory.TrackingCategoryID).to.not.equal("");
+                                        expect(trackingCategory.TrackingCategoryID).to.not.equal(undefined);
+
+                                        expect(trackingCategory.TrackingOptionID).to.not.equal("");
+                                        expect(trackingCategory.TrackingOptionID).to.not.equal(undefined);
+                                    });
+                                }
+                            }
+                        });
+                    } else {
+                        console.log("Credit note has no line item records");
+                    }
+                    done();
+                })
+                .catch(function(err) {
+                    console.log(err);
+                    done(wrapError(err));
+                })
+        });
+
+        it('creates a draft credit note', function(done) {
+
+            var creditNoteData = {
+                Type: 'ACCPAYCREDIT',
+                Contact: {
+                    ContactID: ''
+                },
+                LineItems: [{
+                    Description: 'MacBook - White',
+                    Quantity: 1,
+                    UnitAmount: 1995.00,
+                    AccountCode: salesAccount
+                }]
+            };
+
+            currentApp.core.contacts.getContacts()
+                .then(function(contacts) {
+                    creditNoteData.Contact.ContactID = _.first(contacts).ContactID;
+
+                    var creditNote = currentApp.core.creditNotes.newCreditNote(creditNoteData);
+
+                    creditNote.save()
+                        .then(function(creditNotes) {
+                            expect(creditNotes.entities).to.have.length(1);
+                            var thisNote = creditNotes.entities[0];
+
+                            creditNoteID = thisNote.CreditNoteID;
+
+                            expect(thisNote.Type).to.equal(creditNoteData.Type);
+                            expect(thisNote.Contact.ContactID).to.equal(creditNoteData.Contact.ContactID);
+
+                            thisNote.LineItems.forEach(function(lineItem) {
+                                expect(lineItem.Description).to.equal(creditNoteData.LineItems[0].Description);
+                                expect(lineItem.Quantity).to.equal(creditNoteData.LineItems[0].Quantity);
+                                expect(lineItem.UnitAmount).to.equal(creditNoteData.LineItems[0].UnitAmount);
+                                expect(lineItem.AccountCode.toLowerCase()).to.equal(creditNoteData.LineItems[0].AccountCode.toLowerCase());
+                            });
+
+                            done();
+                        })
+                        .catch(function(err) {
+                            console.log(util.inspect(err, null, null));
+                            done(wrapError(err));
+                        })
+                })
+                .catch(function(err) {
+                    console.log(util.inspect(err, null, null));
+                    done(wrapError(err));
+                })
+
+        });
+
+        it('approves a credit note', function(done) {
+
+            //Get the draft credit note, update it, and save it.
+            currentApp.core.creditNotes.getCreditNote(creditNoteID)
+                .then(function(creditNote) {
+
+                    creditNote.Status = 'AUTHORISED';
+                    creditNote.Date = new Date().toISOString().split("T")[0];
+
+                    creditNote.save()
+                        .then(function(savedCreditNote) {
+                            expect(savedCreditNote.entities).to.have.length(1);
+                            var thisNote = savedCreditNote.entities[0];
+                            expect(thisNote.Status).to.equal('AUTHORISED');
+                            done();
+                        })
+                        .catch(function(err) {
+                            console.log(util.inspect(err, null, null));
+                            done(wrapError(err));
+                        });
+
+                })
+                .catch(function(err) {
+                    console.log(util.inspect(err, null, null));
+                    done(wrapError(err));
+                });
+        });
+
+        it('adds an allocation to a credit note', function(done) {
+
+            currentApp.core.invoices.getInvoices({ where: 'Type == "ACCPAY" and Status != "PAID"' })
+                .then(function(invoices) {
+                    expect(invoices).to.have.length.greaterThan(0);
+
+                    var myInvoice = invoices[0];
+                    var myContact = myInvoice.Contact;
+                    var myCreditNoteAmount = myInvoice.Total / 2; //50% of total invoice
+
+                    //Create the credit note.
+                    var creditNoteData = {
+                        Type: 'ACCPAYCREDIT',
+                        Contact: {
+                            ContactID: myContact.ContactID
+                        },
+                        LineItems: [{
+                            Description: 'Credit',
+                            Quantity: 1,
+                            UnitAmount: myCreditNoteAmount,
+                            AccountCode: salesAccount
+                        }],
+                        Status: 'AUTHORISED',
+                        Date: new Date().toISOString().split("T")[0]
+                    };
+
+                    var creditNote = currentApp.core.creditNotes.newCreditNote(creditNoteData);
+
+                    creditNote.save()
+                        .then(function(creditNotes) {
+                            expect(creditNotes.entities).to.have.length(1);
+                            var thisNote = creditNotes.entities[0];
+
+                            //Now apply the allocation to the original invoice.
+                            var allocations = [{
+                                AppliedAmount: myCreditNoteAmount,
+                                InvoiceID: myInvoice.InvoiceID
+                            }];
+
+                            thisNote.saveAllocations(allocations)
+                                .then(function(res) {
+                                    //console.log(res);
+                                    done();
+                                })
+                                .catch(function(err) {
+                                    console.log(util.inspect(err, null, null));
+                                    done(wrapError(err));
+                                });
+
+
+                        })
+                        .catch(function(err) {
+                            console.log(util.inspect(err, null, null));
+                            done(wrapError(err));
+                        });
+
+
+
+                })
+                .catch(function(err) {
+                    console.log(util.inspect(err, null, null));
+                    done(wrapError(err));
+                });
+
+        });
+
+
+    });
+
+    describe('currencies', function() {
+
+        it('get', function(done) {
+            currentApp.core.currencies.getCurrencies()
+                .then(function(currencies) {
+                    expect(currencies).to.have.length.greaterThan(0);
+                    currencies.forEach(function(currencies) {
+                        expect(currencies.Code).to.not.equal(undefined);
+                        expect(currencies.Code).to.not.equal("");
+                        expect(currencies.Description).to.not.equal(undefined);
+                        expect(currencies.Description).to.not.equal("");
+                    });
+                    done();
+                })
+                .catch(function(err) {
+                    console.log(err);
+                    done(wrapError(err));
+                })
+        });
+    });
+
+    describe('Invoice Reminders', function() {
+
+        it('get', function(done) {
+            currentApp.core.invoiceReminders.getInvoiceReminders()
+                .then(function(invoiceReminders) {
+                    expect(invoiceReminders).to.have.length.greaterThan(0);
+                    invoiceReminders.forEach(function(invoiceReminder) {
+                        expect(invoiceReminder.Enabled).to.be.oneOf([true, false]);
+                    });
+                    done();
+                })
+                .catch(function(err) {
+                    console.log(err);
+                    done(wrapError(err));
+                })
+        });
+    });
+
+
+
+    describe('branding themes', function() {
+
+        var brandingThemeID = "";
+
+        it('get', function(done) {
+            currentApp.core.brandingThemes.getBrandingThemes()
+                .then(function(brandingThemes) {
+                    expect(brandingThemes).to.have.length.greaterThan(0);
+                    brandingThemes.forEach(function(brandingTheme) {
+                        expect(brandingTheme.BrandingThemeID).to.not.equal(undefined);
+                        expect(brandingTheme.BrandingThemeID).to.not.equal("");
+                        expect(brandingTheme.Name).to.not.equal(undefined);
+                        expect(brandingTheme.Name).to.not.equal("");
+
+                        brandingThemeID = brandingTheme.BrandingThemeID;
+                    });
+                    done();
+                })
+                .catch(function(err) {
+                    console.log(err);
+                    done(wrapError(err));
+                })
+        });
+
+        it('get by ID', function(done) {
+            currentApp.core.brandingThemes.getBrandingTheme(brandingThemeID)
+                .then(function(brandingTheme) {
+
+                    expect(brandingTheme.BrandingThemeID).to.not.equal(undefined);
+                    expect(brandingTheme.BrandingThemeID).to.not.equal("");
+                    expect(brandingTheme.Name).to.not.equal(undefined);
+                    expect(brandingTheme.Name).to.not.equal("");
+
+                    done();
+                })
+                .catch(function(err) {
+                    console.log(err);
+                    done(wrapError(err));
+                })
+        })
+    })
+
+    describe('taxRates', function() {
+
+        var createdTaxRate;
+
+        it('gets tax rates', function(done) {
+            currentApp.core.taxRates.getTaxRates()
+                .then(function(taxRates) {
+                    // This test requires that some tax rates are set up in the targeted company
+                    expect(taxRates).to.have.length.greaterThan(0);
+                    _.each(taxRates, function(taxRate) {
+                        expect(taxRate.Name).to.not.equal("");
+                        expect(taxRate.Name).to.not.equal(undefined);
+                        expect(taxRate.TaxType).to.not.equal("");
+                        expect(taxRate.TaxType).to.not.equal(undefined);
+                        expect(taxRate.CanApplyToAssets).to.be.oneOf([true, false]);
+                        expect(taxRate.CanApplyToEquity).to.be.oneOf([true, false]);
+                        expect(taxRate.CanApplyToExpenses).to.be.oneOf([true, false]);
+                        expect(taxRate.CanApplyToLiabilities).to.be.oneOf([true, false]);
+                        expect(taxRate.CanApplyToRevenue).to.be.oneOf([true, false]);
+                        expect(taxRate.DisplayTaxRate).to.be.a('Number');
+                        expect(taxRate.Status).to.be.oneOf(['ACTIVE', 'DELETED', 'ARCHIVED']);
+                        expect(taxRate.TaxComponents).to.have.length.greaterThan(0);
+
+                        _.each(taxRate.TaxComponents, function(taxComponent) {
+                            expect(taxComponent.Name).to.not.equal("");
+                            expect(taxComponent.Name).to.not.equal(undefined);
+                            expect(taxComponent.Rate).to.be.a('String');
+                            //Hacked to a string as the framework doesn't recursively translate nested objects
+                            expect(taxComponent.IsCompound).to.be.oneOf(["true", "false"]);
+                        });
+                    });
+                    done();
+                })
+                .catch(function(err) {
+                    console.log(err);
+                    done(wrapError(err));
+                })
+        });
+
+        it('creates a new tax rate', function(done) {
+            var taxrate = {
+                Name: '20% GST on Expenses',
+                TaxComponents: [{
+                    Name: 'GST',
+                    Rate: 20.1234,
+                    IsCompound: false
+                }]
+            };
+
+            if (["AU", "NZ", "UK"].indexOf(organisationCountry) > -1) {
+                //we're an Org country that needs a report tax type so:
+                taxrate.ReportTaxType = 'INPUT';
+            }
+
+            var taxRate = currentApp.core.taxRates.newTaxRate(taxrate);
+
+            taxRate.save()
+                .then(function(response) {
+                    expect(response.entities).to.have.length.greaterThan(0);
+                    createdTaxRate = response.entities[0];
+
+                    expect(createdTaxRate.Name).to.equal(taxrate.Name);
+                    expect(createdTaxRate.TaxType).to.match(/TAX[0-9]{3}/);
+                    expect(createdTaxRate.CanApplyToAssets).to.be.oneOf([true, false]);
+                    expect(createdTaxRate.CanApplyToEquity).to.be.oneOf([true, false]);
+                    expect(createdTaxRate.CanApplyToExpenses).to.be.oneOf([true, false]);
+                    expect(createdTaxRate.CanApplyToLiabilities).to.be.oneOf([true, false]);
+                    expect(createdTaxRate.CanApplyToRevenue).to.be.oneOf([true, false]);
+                    expect(createdTaxRate.DisplayTaxRate).to.equal(taxrate.TaxComponents[0].Rate);
+                    expect(createdTaxRate.EffectiveRate).to.equal(taxrate.TaxComponents[0].Rate);
+                    expect(createdTaxRate.Status).to.equal('ACTIVE');
+                    expect(createdTaxRate.ReportTaxType).to.equal(taxrate.ReportTaxType);
+
+                    createdTaxRate.TaxComponents.forEach(function(taxComponent) {
+                        expect(taxComponent.Name).to.equal(taxrate.TaxComponents[0].Name);
+
+                        //This is hacked toString() because of: https://github.com/jordanwalsh23/xero-node/issues/13
+                        expect(taxComponent.Rate).to.equal(taxrate.TaxComponents[0].Rate.toString());
+                        expect(taxComponent.IsCompound).to.equal(taxrate.TaxComponents[0].IsCompound.toString());
+                    });
+                    done();
+                })
+                .catch(function(err) {
+                    console.log(err);
+                    done(wrapError(err));
+                })
+        });
+
+        it('updates the taxrate to DELETED', function(done) {
+
+            createdTaxRate.delete()
+                .then(function(response) {
+                    expect(response.entities).to.have.lengthOf(1);
+                    expect(response.entities[0].Status).to.equal("DELETED");
+                    done();
+                })
+                .catch(function(err) {
+                    console.log(err);
+                    done(wrapError(err));
+                })
+
+        });
+
+    });
+
     describe('invoices', function() {
         it('create invoice', function(done) {
             var invoice = currentApp.core.invoices.newInvoice({
@@ -1138,7 +1313,7 @@ describe('regression tests', function() {
                     Description: 'Services',
                     Quantity: 2,
                     UnitAmount: 230,
-                    AccountCode: '400'
+                    AccountCode: salesAccount
                 }]
             });
             invoice.save({ unitdp: 4 })
@@ -1198,7 +1373,7 @@ describe('regression tests', function() {
                         Description: 'Test',
                         Quantity: 1,
                         UnitAmount: 200,
-                        AccountCode: '400'
+                        AccountCode: salesAccount
                     })
                     invoice.Status = 'AUTHORISED'
                     invoice.save()
@@ -1234,7 +1409,7 @@ describe('regression tests', function() {
                         Description: 'Services',
                         Quantity: 2,
                         UnitAmount: 230,
-                        AccountCode: '400'
+                        AccountCode: salesAccount
                     }]
                 }));
             }
@@ -1383,7 +1558,7 @@ describe('regression tests', function() {
                 LineItems: [{
                     Description: 'Annual Bank Account Fee',
                     UnitAmount: 250,
-                    AccountCode: '404'
+                    AccountCode: expenseAccount
                 }],
                 BankAccount: {
                     AccountID: bankAccounts[0].id
@@ -1615,7 +1790,7 @@ describe('regression tests', function() {
                             Description: 'Services',
                             Quantity: 2,
                             UnitAmount: 230,
-                            AccountCode: '400',
+                            AccountCode: salesAccount,
                             Tracking: [{
                                 TrackingCategory: {
                                     Name: trackingCategoryName,
@@ -1679,11 +1854,11 @@ describe('regression tests', function() {
             PurchaseDescription: '2014 Merino Sweater',
             PurchaseDetails: {
                 UnitPrice: 149.00,
-                AccountCode: '200'
+                AccountCode: salesAccount
             },
             SalesDetails: {
                 UnitPrice: 299.00,
-                AccountCode: '200'
+                AccountCode: salesAccount
             }
         };
 

--- a/test/accountingtests.js
+++ b/test/accountingtests.js
@@ -215,202 +215,6 @@ describe('get access for public or partner application', function() {
 });
 
 
-describe('reporting tests', function() {
-    this.timeout(10000);
-    it('Generates a Balance Sheet Report', function(done) {
-        currentApp.core.reports.generateReport({ id: 'BalanceSheet' })
-            .then(function(report) {
-                expect(report.ReportType).to.equal('BalanceSheet');
-                expect(report.ReportName).to.equal('Balance Sheet');
-
-                validateRows(report.Rows);
-
-                done();
-            })
-            .catch(function(err) {
-                console.log(err);
-                done(wrapError(err));
-            })
-
-    });
-
-    it('Generates a Bank Statement Report', function(done) {
-        currentApp.core.reports.generateReport({
-                id: 'BankStatement',
-                params: {
-                    bankAccountID: '13918178-849a-4823-9a31-57b7eac713d7'
-                }
-            })
-            .then(function(report) {
-                expect(report.ReportType).to.equal('BankStatement');
-                expect(report.ReportName).to.equal('Bank Statement');
-
-                validateRows(report.Rows);
-
-                done();
-            })
-            .catch(function(err) {
-                console.log(err);
-                done(wrapError(err));
-            })
-
-    });
-
-    it('Generates a Trial Balance Report', function(done) {
-        currentApp.core.reports.generateReport({
-                id: 'TrialBalance'
-            })
-            .then(function(report) {
-                expect(report.ReportType).to.equal('TrialBalance');
-                expect(report.ReportName).to.equal('Trial Balance');
-                validateRows(report.Rows);
-                done();
-            })
-            .catch(function(err) {
-                console.log(err);
-                done(wrapError(err));
-            })
-
-    });
-
-    it('Generates a Profit and Loss Report', function(done) {
-        currentApp.core.reports.generateReport({
-                id: 'ProfitAndLoss'
-            })
-            .then(function(report) {
-                expect(report.ReportType).to.equal('ProfitAndLoss');
-                expect(report.ReportName).to.equal('Profit and Loss');
-                validateRows(report.Rows);
-                done();
-            })
-            .catch(function(err) {
-                console.log(err);
-                done(wrapError(err));
-            })
-
-    });
-
-    it('Generates a Budget Summary Report', function(done) {
-        currentApp.core.reports.generateReport({
-                id: 'BudgetSummary'
-            })
-            .then(function(report) {
-                expect(report.ReportType).to.equal('BudgetSummary');
-                expect(report.ReportName).to.equal('Budget Summary');
-                validateRows(report.Rows);
-                done();
-            })
-            .catch(function(err) {
-                console.log(err);
-                done(wrapError(err));
-            })
-
-    });
-
-    it('Generates an Executive Summary Report', function(done) {
-        currentApp.core.reports.generateReport({
-                id: 'ExecutiveSummary'
-            })
-            .then(function(report) {
-                expect(report.ReportType).to.equal('ExecutiveSummary');
-                expect(report.ReportName).to.equal('Executive Summary');
-                validateRows(report.Rows);
-                done();
-            })
-            .catch(function(err) {
-                console.log(err);
-                done(wrapError(err));
-            })
-
-    });
-
-    it('Generates a Bank Summary Report', function(done) {
-        currentApp.core.reports.generateReport({
-                id: 'BankSummary'
-            })
-            .then(function(report) {
-                expect(report.ReportType).to.equal('BankSummary');
-                expect(report.ReportName).to.equal('Bank Summary');
-                validateRows(report.Rows);
-                done();
-            })
-            .catch(function(err) {
-                console.log(err);
-                done(wrapError(err));
-            })
-
-    });
-
-    it('Generates an Aged Receivables Report', function(done) {
-        currentApp.core.reports.generateReport({
-                id: 'AgedReceivablesByContact',
-                params: {
-                    contactId: '58697449-85ef-46ae-83fc-6a9446f037fb'
-                }
-            })
-            .then(function(report) {
-                expect(report.ReportType).to.equal('AgedReceivablesByContact');
-                expect(report.ReportName).to.equal('Aged Receivables By Contact');
-                validateRows(report.Rows);
-                done();
-            })
-            .catch(function(err) {
-                console.log(err);
-                done(wrapError(err));
-            })
-
-    });
-
-    it('Generates an Aged Payables Report', function(done) {
-        currentApp.core.reports.generateReport({
-                id: 'AgedPayablesByContact',
-                params: {
-                    contactId: '58697449-85ef-46ae-83fc-6a9446f037fb'
-                }
-            })
-            .then(function(report) {
-                expect(report.ReportType).to.equal('AgedPayablesByContact');
-                expect(report.ReportName).to.equal('Aged Payables By Contact');
-                validateRows(report.Rows);
-                done();
-            })
-            .catch(function(err) {
-                console.log(err);
-                done(wrapError(err));
-            })
-
-    });
-
-    function validateRows(rows) {
-        expect(rows).to.have.length.greaterThan(0);
-        rows.forEach(function(row) {
-            expect(row.RowType).to.be.oneOf(['Header', 'Section', 'Row', 'SummaryRow']);
-
-            //Each row can have some cells, each cell should have some data.
-            if (row.Cells) {
-                validateCells(row);
-            }
-
-            if (row.Rows && row.Rows.length > 0) {
-                row.Rows.forEach(function(thisRow) {
-                    validateCells(thisRow);
-                })
-            }
-
-            function validateCells(row) {
-                expect(row.Cells).to.have.length.greaterThan(0);
-                row.Cells.forEach(function(cell) {
-                    //each cell can either be a string or an object
-                    expect(cell).to.not.equal(undefined);
-                    expect(cell).to.satisfy(function(c) { return typeof c === "string" || typeof c === "object" });
-                });
-            }
-
-        });
-    }
-
-})
-
 describe('regression tests', function() {
     var InvoiceID = "";
     var PaymentID = "";
@@ -479,6 +283,224 @@ describe('regression tests', function() {
 
     });
 
+    describe('reporting tests', function() {
+        it('Generates a Balance Sheet Report', function(done) {
+            currentApp.core.reports.generateReport({ id: 'BalanceSheet' })
+                .then(function(report) {
+                    expect(report.ReportType).to.equal('BalanceSheet');
+                    expect(report.ReportName).to.equal('Balance Sheet');
+
+                    validateRows(report.Rows);
+
+                    done();
+                })
+                .catch(function(err) {
+                    console.log(err);
+                    done(wrapError(err));
+                })
+
+        });
+
+        it('Generates a Bank Statement Report', function(done) {
+            currentApp.core.reports.generateReport({
+                    id: 'BankStatement',
+                    params: {
+                        bankAccountID: bankAccounts[0].id
+                    }
+                })
+                .then(function(report) {
+                    expect(report.ReportType).to.equal('BankStatement');
+                    expect(report.ReportName).to.equal('Bank Statement');
+
+                    validateRows(report.Rows);
+
+                    done();
+                })
+                .catch(function(err) {
+                    console.log(err);
+                    done(wrapError(err));
+                })
+
+        });
+
+        it('Generates a Trial Balance Report', function(done) {
+            currentApp.core.reports.generateReport({
+                    id: 'TrialBalance'
+                })
+                .then(function(report) {
+                    expect(report.ReportType).to.equal('TrialBalance');
+                    expect(report.ReportName).to.equal('Trial Balance');
+                    validateRows(report.Rows);
+                    done();
+                })
+                .catch(function(err) {
+                    console.log(err);
+                    done(wrapError(err));
+                })
+
+        });
+
+        it('Generates a Profit and Loss Report', function(done) {
+            currentApp.core.reports.generateReport({
+                    id: 'ProfitAndLoss'
+                })
+                .then(function(report) {
+                    expect(report.ReportType).to.equal('ProfitAndLoss');
+                    expect(report.ReportName).to.equal('Profit and Loss');
+                    validateRows(report.Rows);
+                    done();
+                })
+                .catch(function(err) {
+                    console.log(err);
+                    done(wrapError(err));
+                })
+
+        });
+
+        it('Generates a Budget Summary Report', function(done) {
+            currentApp.core.reports.generateReport({
+                    id: 'BudgetSummary'
+                })
+                .then(function(report) {
+                    expect(report.ReportType).to.equal('BudgetSummary');
+                    expect(report.ReportName).to.equal('Budget Summary');
+                    validateRows(report.Rows);
+                    done();
+                })
+                .catch(function(err) {
+                    console.log(err);
+                    done(wrapError(err));
+                })
+
+        });
+
+        it('Generates an Executive Summary Report', function(done) {
+            currentApp.core.reports.generateReport({
+                    id: 'ExecutiveSummary'
+                })
+                .then(function(report) {
+                    expect(report.ReportType).to.equal('ExecutiveSummary');
+                    expect(report.ReportName).to.equal('Executive Summary');
+                    validateRows(report.Rows);
+                    done();
+                })
+                .catch(function(err) {
+                    console.log(err);
+                    done(wrapError(err));
+                })
+
+        });
+
+        it('Generates a Bank Summary Report', function(done) {
+            currentApp.core.reports.generateReport({
+                    id: 'BankSummary'
+                })
+                .then(function(report) {
+                    expect(report.ReportType).to.equal('BankSummary');
+                    expect(report.ReportName).to.equal('Bank Summary');
+                    validateRows(report.Rows);
+                    done();
+                })
+                .catch(function(err) {
+                    console.log(err);
+                    done(wrapError(err));
+                })
+
+        });
+
+
+
+        it('Generates an Aged Receivables Report', function(done) {
+
+            var someContactId = "";
+            currentApp.core.contacts.getContacts()
+                .then(function(contacts) {
+                    someContactId = _.first(contacts).ContactID;
+
+                    currentApp.core.reports.generateReport({
+                            id: 'AgedReceivablesByContact',
+                            params: {
+                                contactId: someContactId
+                            }
+                        })
+                        .then(function(report) {
+                            expect(report.ReportType).to.equal('AgedReceivablesByContact');
+                            expect(report.ReportName).to.equal('Aged Receivables By Contact');
+                            validateRows(report.Rows);
+                            done();
+                        })
+                        .catch(function(err) {
+                            throw err;
+                        })
+                })
+                .catch(function(err) {
+                    console.log(util.inspect(err, null, null));
+                    done(wrapError(err));
+                })
+
+
+
+        });
+
+        it('Generates an Aged Payables Report', function(done) {
+
+            var someContactId = "";
+            currentApp.core.contacts.getContacts()
+                .then(function(contacts) {
+                    someContactId = _.first(contacts).ContactID;
+
+                    currentApp.core.reports.generateReport({
+                            id: 'AgedPayablesByContact',
+                            params: {
+                                contactId: someContactId
+                            }
+                        })
+                        .then(function(report) {
+                            expect(report.ReportType).to.equal('AgedPayablesByContact');
+                            expect(report.ReportName).to.equal('Aged Payables By Contact');
+                            validateRows(report.Rows);
+                            done();
+                        })
+                        .catch(function(err) {
+                            throw err;
+                        })
+                })
+                .catch(function(err) {
+                    console.log(util.inspect(err, null, null));
+                    done(wrapError(err));
+                })
+        });
+
+        function validateRows(rows) {
+            expect(rows).to.have.length.greaterThan(0);
+            rows.forEach(function(row) {
+                expect(row.RowType).to.be.oneOf(['Header', 'Section', 'Row', 'SummaryRow']);
+
+                //Each row can have some cells, each cell should have some data.
+                if (row.Cells) {
+                    validateCells(row);
+                }
+
+                if (row.Rows && row.Rows.length > 0) {
+                    row.Rows.forEach(function(thisRow) {
+                        validateCells(thisRow);
+                    })
+                }
+
+                function validateCells(row) {
+                    expect(row.Cells).to.have.length.greaterThan(0);
+                    row.Cells.forEach(function(cell) {
+                        //each cell can either be a string or an object
+                        expect(cell).to.not.equal(undefined);
+                        expect(cell).to.satisfy(function(c) { return typeof c === "string" || typeof c === "object" });
+                    });
+                }
+
+            });
+        }
+
+    })
+
     describe('organisations', function() {
         it('get', function(done) {
             currentApp.core.organisations.getOrganisation()
@@ -498,6 +520,232 @@ describe('regression tests', function() {
                     done(wrapError(err));
                 })
         })
+    });
+
+    describe('Credit Notes', function() {
+        var creditNoteID = "";
+        it('get', function(done) {
+            currentApp.core.creditNotes.getCreditNotes()
+                .then(function(creditNotes) {
+                    expect(creditNotes).to.have.length.greaterThan(0);
+                    creditNotes.forEach(function(creditNote) {
+                        //Check the contact
+                        if (creditNote.Contact) {
+                            expect(creditNote.Contact.ContactID).to.not.equal("");
+                            expect(creditNote.Contact.ContactID).to.not.equal(undefined);
+                            expect(creditNote.Contact.Name).to.not.equal("");
+                            expect(creditNote.Contact.Name).to.not.equal(undefined);
+                        } else {
+                            console.log("Credit note has no contact record");
+                        }
+
+                        expect(creditNote.Date).to.not.equal("");
+                        expect(creditNote.Date).to.not.equal(undefined);
+
+                        expect(creditNote.Status).to.be.oneOf(["DRAFT", "SUBMITTED", "DELETED", "AUTHORISED", "PAID", "VOIDED"]);
+                        expect(creditNote.LineAmountTypes).to.be.oneOf(["Exclusive", "Inclusive", "NoTax"]);
+
+                        expect(creditNote.SubTotal).to.be.a('Number');
+                        expect(creditNote.SubTotal).to.be.greaterThan(0);
+                        expect(creditNote.TotalTax).to.be.a('Number');
+                        expect(creditNote.TotalTax).to.be.greaterThan(0);
+                        expect(creditNote.Total).to.be.a('Number');
+                        expect(creditNote.Total).to.be.greaterThan(0);
+
+                        expect(creditNote.UpdatedDateUTC).to.not.equal("");
+                        expect(creditNote.UpdatedDateUTC).to.not.equal(undefined);
+
+                        expect(creditNote.CurrencyCode).to.not.equal("");
+                        expect(creditNote.CurrencyCode).to.not.equal(undefined);
+
+                        expect(creditNote.FullyPaidOnDate).to.not.equal("");
+                        expect(creditNote.FullyPaidOnDate).to.not.equal(undefined);
+
+                        expect(creditNote.Type).to.be.oneOf(["ACCPAYCREDIT", "ACCRECCREDIT"]);
+
+                        expect(creditNote.CreditNoteID).to.not.equal("");
+                        expect(creditNote.CreditNoteID).to.not.equal(undefined);
+
+                        //Set the variable for the next test.
+                        creditNoteID = creditNote.CreditNoteID;
+
+                        expect(creditNote.CreditNoteNumber).to.not.equal("");
+                        expect(creditNote.CreditNoteNumber).to.not.equal(undefined);
+
+                        expect(creditNote.CurrencyRate).to.be.a('Number');
+                        expect(creditNote.CurrencyRate).to.be.greaterThan(0);
+
+                        expect(creditNote.RemainingCredit).to.be.a('Number');
+                        expect(creditNote.RemainingCredit).to.be.at.least(0);
+
+                        if (creditNote.Allocations) {
+                            creditNote.Allocations.forEach(function(allocation) {
+                                expect(allocation.AppliedAmount).to.be.a('Number');
+                                expect(allocation.AppliedAmount).to.be.at.least(0);
+
+                                expect(allocation.Date).to.not.equal("");
+                                expect(allocation.Date).to.not.equal(undefined);
+
+                                if (allocation.Invoice) {
+                                    expect(allocation.Invoice.InvoiceID).to.not.equal("");
+                                    expect(allocation.Invoice.InvoiceID).to.not.equal(undefined);
+
+                                    expect(allocation.Invoice.InvoiceNumber).to.not.equal("");
+                                    expect(allocation.Invoice.InvoiceNumber).to.not.equal(undefined);
+                                } else {
+                                    console.log("Credit note allocation has no invoice record");
+                                }
+                            });
+                        } else {
+                            console.log("Credit note has no allocation records");
+                        }
+                    });
+                    done();
+                })
+                .catch(function(err) {
+                    console.log(err);
+                    done(wrapError(err));
+                })
+        });
+
+        it('get a single credit note', function(done) {
+            currentApp.core.creditNotes.getCreditNote(creditNoteID)
+                .then(function(creditNote) {
+                    //Check the contact
+                    if (creditNote.Contact) {
+                        expect(creditNote.Contact.ContactID).to.not.equal("");
+                        expect(creditNote.Contact.ContactID).to.not.equal(undefined);
+                        expect(creditNote.Contact.Name).to.not.equal("");
+                        expect(creditNote.Contact.Name).to.not.equal(undefined);
+                    } else {
+                        console.log("Credit note has no contact record");
+                    }
+
+                    expect(creditNote.Date).to.not.equal("");
+                    expect(creditNote.Date).to.not.equal(undefined);
+
+                    expect(creditNote.Status).to.be.oneOf(["DRAFT", "SUBMITTED", "DELETED", "AUTHORISED", "PAID", "VOIDED"]);
+                    expect(creditNote.LineAmountTypes).to.be.oneOf(["Exclusive", "Inclusive", "NoTax"]);
+
+                    expect(creditNote.SubTotal).to.be.a('Number');
+                    expect(creditNote.SubTotal).to.be.greaterThan(0);
+                    expect(creditNote.TotalTax).to.be.a('Number');
+                    expect(creditNote.TotalTax).to.be.greaterThan(0);
+                    expect(creditNote.Total).to.be.a('Number');
+                    expect(creditNote.Total).to.be.greaterThan(0);
+
+                    expect(creditNote.UpdatedDateUTC).to.not.equal("");
+                    expect(creditNote.UpdatedDateUTC).to.not.equal(undefined);
+
+                    expect(creditNote.CurrencyCode).to.not.equal("");
+                    expect(creditNote.CurrencyCode).to.not.equal(undefined);
+
+                    expect(creditNote.FullyPaidOnDate).to.not.equal("");
+                    expect(creditNote.FullyPaidOnDate).to.not.equal(undefined);
+
+                    expect(creditNote.Type).to.be.oneOf(["ACCPAYCREDIT", "ACCRECCREDIT"]);
+
+                    expect(creditNote.CreditNoteID).to.not.equal("");
+                    expect(creditNote.CreditNoteID).to.not.equal(undefined);
+
+                    //Set the variable for the next test.
+                    creditNoteID = creditNote.CreditNoteID;
+
+                    expect(creditNote.CreditNoteNumber).to.not.equal("");
+                    expect(creditNote.CreditNoteNumber).to.not.equal(undefined);
+
+                    expect(creditNote.CurrencyRate).to.be.a('Number');
+                    expect(creditNote.CurrencyRate).to.be.greaterThan(0);
+
+                    expect(creditNote.RemainingCredit).to.be.a('Number');
+                    expect(creditNote.RemainingCredit).to.be.at.least(0);
+
+                    if (creditNote.Allocations) {
+                        creditNote.Allocations.forEach(function(allocation) {
+                            expect(allocation.AppliedAmount).to.be.a('Number');
+                            expect(allocation.AppliedAmount).to.be.at.least(0);
+
+                            expect(allocation.Date).to.not.equal("");
+                            expect(allocation.Date).to.not.equal(undefined);
+
+                            if (allocation.Invoice) {
+                                expect(allocation.Invoice.InvoiceID).to.not.equal("");
+                                expect(allocation.Invoice.InvoiceID).to.not.equal(undefined);
+
+                                expect(allocation.Invoice.InvoiceNumber).to.not.equal("");
+                                expect(allocation.Invoice.InvoiceNumber).to.not.equal(undefined);
+                            } else {
+                                console.log("Credit note allocation has no invoice record");
+                            }
+                        });
+                    } else {
+                        console.log("Credit note has no allocation records");
+                    }
+
+                    if (creditNote.LineItems) {
+                        creditNote.LineItems.forEach(function(lineItem) {
+
+                            if (lineItem.LineItemID) {
+                                expect(lineItem.LineItemID).to.not.equal("");
+                            }
+
+                            expect(lineItem.Description).to.not.equal("");
+                            expect(lineItem.Description).to.not.equal(undefined);
+
+                            if (lineItem.Quantity) {
+                                expect(lineItem.Quantity).to.be.a('Number');
+                                expect(lineItem.Quantity).to.be.at.least(0);
+
+                                expect(lineItem.UnitAmount).to.be.a('Number');
+                                expect(lineItem.UnitAmount).to.be.at.least(0);
+
+                                expect(lineItem.ItemCode).to.be.a('String');
+                                expect(lineItem.ItemCode).to.not.equal("");
+                                expect(lineItem.ItemCode).to.not.equal(undefined);
+
+                                expect(lineItem.AccountCode).to.be.a('String');
+                                expect(lineItem.AccountCode).to.not.equal("");
+                                expect(lineItem.AccountCode).to.not.equal(undefined);
+
+                                expect(lineItem.TaxType).to.not.equal("");
+                                expect(lineItem.TaxType).to.not.equal(undefined);
+
+                                expect(lineItem.TaxAmount).to.be.a('Number');
+                                expect(lineItem.TaxAmount).to.be.at.least(0);
+
+                                expect(lineItem.LineAmount).to.be.a('Number');
+                                expect(lineItem.LineAmount).to.be.at.least(0);
+
+                                if (lineItem.Tracking) {
+                                    lineItem.Tracking.forEach(function(trackingCategory) {
+                                        expect(trackingCategory.Name).to.not.equal("");
+                                        expect(trackingCategory.Name).to.not.equal(undefined);
+
+                                        expect(trackingCategory.Option).to.not.equal("");
+                                        expect(trackingCategory.Option).to.not.equal(undefined);
+
+                                        expect(trackingCategory.TrackingCategoryID).to.not.equal("");
+                                        expect(trackingCategory.TrackingCategoryID).to.not.equal(undefined);
+
+                                        expect(trackingCategory.TrackingOptionID).to.not.equal("");
+                                        expect(trackingCategory.TrackingOptionID).to.not.equal(undefined);
+                                    });
+                                }
+                            }
+
+
+
+                        });
+                    } else {
+                        console.log("Credit note has no line item records");
+                    }
+                    done();
+                })
+                .catch(function(err) {
+                    console.log(err);
+                    done(wrapError(err));
+                })
+        });
     });
 
     describe('currencies', function() {
@@ -521,7 +769,7 @@ describe('regression tests', function() {
         });
     });
 
-    describe.only('Invoice Reminders', function() {
+    describe('Invoice Reminders', function() {
 
         it('get', function(done) {
             currentApp.core.invoiceReminders.getInvoiceReminders()
@@ -538,6 +786,8 @@ describe('regression tests', function() {
                 })
         });
     });
+
+
 
     describe('branding themes', function() {
 


### PR DESCRIPTION
This PR adds the following functions:

- Support for creating and updating Credit Notes
- Support for adding allocations to Credit Notes.

In this merge I have also fixed the following:

- Fixed Tracking Options (this was broken by a previous merge)
- Refactored the `asArray` function as this wasn't in the correct place